### PR TITLE
fix python missing key error which results from cast error in CPP

### DIFF
--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
-
 using namespace pybind11::literals;
 
 namespace coco_eval
@@ -85,7 +84,7 @@ namespace coco_eval
       std::vector<uint64_t> &ground_truth_matches = results->ground_truth_matches;
       ground_truth_matches.resize(num_iou_thresholds * num_ground_truth, 0);
 
-      std::vector<int> &ground_truth_orig_id = results->ground_truth_orig_id;
+      std::vector<uint64_t> &ground_truth_orig_id = results->ground_truth_orig_id;
       ground_truth_orig_id.resize(num_iou_thresholds * num_ground_truth, -1);
 
       std::vector<uint64_t> &detection_matches = results->detection_matches;
@@ -142,7 +141,7 @@ namespace coco_eval
                 ground_truth_instances[ground_truth_sorted_indices[match]].id;
             ground_truth_matches[t * num_ground_truth + match] =
                 detection_instances[detection_sorted_indices[d]].id;
-            ground_truth_orig_id[t * num_ground_truth + match] = (int)ground_truth_instances[ground_truth_sorted_indices[match]].id;
+            ground_truth_orig_id[t * num_ground_truth + match] = (long)ground_truth_instances[ground_truth_sorted_indices[match]].id;
           }
 
           // set unmatched detections outside of area range to ignore
@@ -548,7 +547,7 @@ namespace coco_eval
 
       std::vector<uint64_t> out_detection_matches = {};
       std::vector<uint64_t> out_ground_truth_matches = {};
-      std::vector<int> out_ground_truth_orig_id = {};
+      std::vector<uint64_t> out_ground_truth_orig_id = {};
       for (auto eval : evaluations)
       {
         out_detection_matches.insert(out_detection_matches.end(), eval.detection_matches.begin(), eval.detection_matches.end());

--- a/csrc/faster_eval_api/coco_eval/cocoeval.h
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.h
@@ -42,7 +42,7 @@ namespace coco_eval
       std::vector<uint64_t> detection_matches;
 
       std::vector<uint64_t> ground_truth_matches;
-      std::vector<int> ground_truth_orig_id;
+      std::vector<uint64_t> ground_truth_orig_id;
       // The detection score of each of the D detected instances
       std::vector<double> detection_scores;
 


### PR DESCRIPTION
This PR fixes a bug when running `COCOeval_faster` with `extra_calc=True` on large annotation files, e.g. on ms-coco `instances_val2017.json`. Note that the standard metrics are not affected by this problem (`extra_calc=False`)!

The problem is a loss of data in the CPP code when very large IDs (> max int32) are casted from long to int. Back in python, this causes the following error in `math_matches`: `KeyError: 56971388`. The loss of data from casting can be reproduced in python as follows:

```python
import numpy as np
print(np.array([902000103548]).astype(np.int32)[0])
# > 56971388
```

In `cocoeval.cpp`, this happens at [line 145](https://github.com/MiXaiLL76/faster_coco_eval/blob/main/csrc/faster_eval_api/coco_eval/cocoeval.cpp#L145):
```c++
ground_truth_orig_id[t * num_ground_truth + match] = (int)ground_truth_instances[ground_truth_sorted_indices[match]].id;
```

This PR fixes the types and cast accordingly so that `mIoU` and `mAUC_50` can be calculated.

## reproduce

Prepare setup:

```bash
wget http://images.cocodataset.org/annotations/annotations_trainval2017.zip
unzip annotations_trainval2017.zip
pip install faster-coco-eval==1.5.5
```

Run python code:

```python
from faster_coco_eval import COCO
from faster_coco_eval import COCOeval_faster as COCOeval

# annotations and fake results
annoation_file = "./annotations/instances_val2017.json"
with open(annoation_file, 'r') as f:
        anns = json.load(f)
        results = anns['annotations']
        for r in results:
            r['score'] = 1

cocoGt = COCO(annoation_file)
cocoDt = cocoGt.loadRes(results)

cocoEval = COCOeval(cocoGt, cocoDt, "bbox", print_function=print, extra_calc=True)  # or 'segm', doesn't matter
cocoEval.evaluate()
cocoEval.accumulate()  # error happens here -> KeyError: 56971388
cocoEval.summarize()   # standard metrics are not affected
print(cocoEval.stats_as_dict)  # 'mIoU' and 'mAUC_50' are missing
```

## test fix

Update setup:

```bash
pip uninstall faster-coco-eval
git clone https://github.com/JohannesTheo/faster_coco_eval.git
cd faster_coco_eval
git checkout fix-cpp-cast-error
pip install .
```

Run python code from above again. The metrics `mIoU` and `mAUC_50` are calculated as expected.

