### PR TITLE
add equalScore param

### DIFF
--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -350,7 +350,8 @@ namespace coco_eval
         std::vector<double> *recalls,
         std::vector<double> *precisions_out,
         std::vector<double> *scores_out,
-        std::vector<double> *recalls_out)
+        std::vector<double> *recalls_out,
+        bool equal_score)
     {
       assert(recalls_out->size() > recalls_out_index);
 
@@ -391,9 +392,15 @@ namespace coco_eval
         recalls->emplace_back(recall);
         const int64_t num_valid_detections =
             true_positives_sum + false_positives_sum;
-        const double precision = num_valid_detections > 0
-                                     ? static_cast<double>(true_positives_sum) / num_valid_detections
-                                     : 0.0;
+
+        double precision = 0;
+        if(equal_score){
+          precision = num_valid_detections > 0 ? 1 : 0.0;
+        }else{
+          precision = num_valid_detections > 0
+              ? static_cast<double>(true_positives_sum) / num_valid_detections
+              : 0.0;
+        }
         precisions->emplace_back(precision);
       }
 
@@ -445,6 +452,7 @@ namespace coco_eval
       const int num_area_ranges = (const int) py::len(params.attr("areaRng"));
       const int num_max_detections = (const int) py::len(params.attr("maxDets"));
       const int num_images = (const int) py::len(params.attr("imgIds"));
+      bool equal_score = params.attr("equalScore").cast<bool>();
 
       std::vector<double> precisions_out(
           num_iou_thresholds * num_recall_thresholds * num_categories *
@@ -537,7 +545,8 @@ namespace coco_eval
                   &recalls,
                   &precisions_out,
                   &scores_out,
-                  &recalls_out);
+                  &recalls_out,
+                  equal_score);
             }
           }
         }

--- a/faster_coco_eval/core/cocoeval.py
+++ b/faster_coco_eval/core/cocoeval.py
@@ -593,6 +593,11 @@ class Params:
         # f: Frequent: >= 100
         self.imgCountLbl = ["r", "c", "f"]
 
+        # https://github.com/MiXaiLL76/faster_coco_eval/issues/46
+        # mAP is wrong if all scores are equal (=not providing a score)
+        # set equalScore = True
+        self.equalScore = False
+
     @property
     def useSegm(self):
         return int(self.iouType == "segm")


### PR DESCRIPTION

## Motivation

[Please describe the motivation of this PR and the goal you want to achieve through this PR.
](https://github.com/MiXaiLL76/faster_coco_eval/issues/46)

## Usage

mAP is wrong if all scores are equal (=not providing a score)
eval.params.equalScore = True


```py
coco = COCO("gt.json")

pred = coco.loadRes("pred1.json")
eval = COCOeval(coco, pred, 'bbox')
eval.params.equalScore = True
eval.evaluate()
eval.accumulate()
eval.summarize()

pred = coco.loadRes("pred2.json")
eval = COCOeval(coco, pred, 'bbox')
eval.params.equalScore = True
eval.evaluate()
eval.accumulate()
eval.summarize()
```


```text
Evaluate annotation type *bbox*
COCOeval_opt.evaluate() finished...
DONE (t=0.00s).
Accumulating evaluation results...
COCOeval_opt.accumulate() finished...
DONE (t=0.00s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = -1.000
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = -1.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.333
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.667
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.667
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.667
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = -1.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = -1.000
 Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.667
 Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.667
Loading and preparing results...
DONE (t=0.00s)
Evaluate annotation type *bbox*
COCOeval_opt.evaluate() finished...
DONE (t=0.00s).
Accumulating evaluation results...
COCOeval_opt.accumulate() finished...
DONE (t=0.00s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.663
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = -1.000
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = -1.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.333
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.667
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.667
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.667
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = -1.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = -1.000
 Average Recall     (AR) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.667
 Average Recall     (AR) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.667
```