### PR TITLE
Adding show_false_only parameter

### DIFF
--- a/faster_coco_eval/extra/display.py
+++ b/faster_coco_eval/extra/display.py
@@ -22,6 +22,7 @@ class PreviewResults(ExtraEval):
         gt_ann_ids: Optional[set] = None,
         dt_ann_ids: Optional[set] = None,
         return_fig: bool = False,
+        show_false_only: bool = False,
     ):
         """Display the image with the results.
 
@@ -36,6 +37,7 @@ class PreviewResults(ExtraEval):
             gt_ann_ids (Optional[set]): Ground truth annotation ids.
             dt_ann_ids (Optional[set]): Detected annotation ids.
             return_fig (bool): Return the figure.
+            show_false_only (bool): If True, only display images that contains false positives or false negatives.
 
         Returns:
             Optional[Any]: The figure object if return_fig is True, otherwise None.
@@ -54,6 +56,7 @@ class PreviewResults(ExtraEval):
             gt_ann_ids=gt_ann_ids,
             dt_ann_ids=dt_ann_ids,
             return_fig=return_fig,
+            show_false_only=show_false_only,
         )
 
     def display_tp_fp_fn(
@@ -65,6 +68,7 @@ class PreviewResults(ExtraEval):
         display_gt: bool = False,
         data_folder: Optional[str] = None,
         categories: Optional[list] = None,
+        show_false_only: bool = False,
     ):
         """Display true positives, false positives, and false negatives for
         given images.
@@ -77,6 +81,7 @@ class PreviewResults(ExtraEval):
             display_gt (bool): Display ground truth.
             data_folder (Optional[str]): Data folder.
             categories (Optional[list]): Categories to display.
+            show_false_only (bool): If True, only display images that contains false positives or false negatives.
 
         Returns:
             None
@@ -97,6 +102,7 @@ class PreviewResults(ExtraEval):
                 display_gt=display_gt,
                 data_folder=data_folder,
                 categories=categories,
+                show_false_only=show_false_only,
             )
 
     def _compute_confusion_matrix(

--- a/faster_coco_eval/extra/draw.py
+++ b/faster_coco_eval/extra/draw.py
@@ -116,6 +116,7 @@ def display_image(
     gt_ann_ids: Optional[set] = None,
     dt_ann_ids: Optional[set] = None,
     return_fig: bool = False,
+    show_false_only: bool = False,
 ) -> Optional[go.Figure]:
     """Display the image with the results.
 
@@ -133,11 +134,13 @@ def display_image(
         gt_ann_ids (set, optional): Set of ground truth annotation ids to display. Default is None.
         dt_ann_ids (set, optional): Set of detection annotation ids to display. Default is None.
         return_fig (bool, optional): Return the figure object instead of displaying it. Default is False.
+        show_false_only (bool, optional): If True, only display images that contains false positives or false negatives. Default is False.
 
     Returns:
         Optional[go.Figure]: The figure object if return_fig is True, otherwise None.
     """
     polygons = []
+    contains_false = False
 
     image = cocoGt.imgs[image_id]
     gt_anns = {ann["id"]: ann for ann in cocoGt.imgToAnns[image_id]}
@@ -178,6 +181,7 @@ def display_image(
                     "category={}".format(categories_labels[ann["category_id"]]),
                 ]
                 if ann.get("fn", False):
+                    contains_false = True
                     if display_fn:
                         fn_text = ["<b>FN</b>"] + _text
                         poly = generate_ann_polygon(
@@ -233,6 +237,7 @@ def display_image(
                         if poly is not None:
                             polygons.append(poly)
                 else:
+                    contains_false = True
                     if display_fp:
                         fp_text = ["<b>FP</b>"] + _text
 
@@ -246,6 +251,9 @@ def display_image(
                         )
                         if poly is not None:
                             polygons.append(poly)
+
+    if show_false_only and contains_false is False:
+        return None
 
     fig = px.imshow(
         im,


### PR DESCRIPTION
## Motivation

I've just used your library for testing my detection models, and I tried to visualize the results using the `display_tp_fp_fn` function. The library’s functions are well-structured but I faced a small limitation: how can I focus only on my model's incorrect detections? I explored the available parameters to see if there was a way to do this, but unfortunately, I didn’t find any. So, I added a new parameter, `show_false_only`.

*If there’s already a parameter or a way to achieve this, feel free to close this PR and let me know how to implement the same functionality using the existing code.*

## Modification

This is a simple modification. I added the `show_false_only` parameter to the `display_image` function inside the `faster_coco_eval/extra/draw.py` script.  

Since this function is called for each image separately, I also introduced a variable called `contains_false`, which indicates whether an image contains at least one false positive or false negative. If it does -and `show_false_only` is **True**- the image will be previewed.  

I also updated other functions that lead to `display_image`, such as `display_tp_fp_fn` and `display_image` from the `PreviewResults` class, to support this new parameter.

## Use cases (Optional)

Here’s an example in case my explanation was unclear:

Let’s say I want to know where exactly my model fails.

If I run:

```python
results = PreviewResults(
    cocoGt, cocoDt, iou_tresh=IOU_THRESHOLD, iouType=iouType, useCats=True
)

results.display_tp_fp_fn(
    data_folder="path_to_annotations.coco.json",
    image_ids=["all"],
    display_tp=False
)
```

This will return all images in my dataset, even if they don’t contain any false positives or false negatives.

For example, the following image has no false predictions, but it still appears in the output:
<img width="755" height="585" alt="image" src="https://github.com/user-attachments/assets/49829133-e151-449b-b53b-7b122d3cf7a5" />

If we scale this up, let's say my dataset contains 100 images, but only 10 of them have false predictions, I would still need to go through all 100 images to find the 10 relevant ones.

After my modifications:
```python
results.display_tp_fp_fn(
    data_folder=COCO_JSON_PATH.replace('/_annotations.coco.json', ''),
    image_ids=["all"],
    display_tp=False,
    show_false_only=True
)
```

The image shown earlier will no longer be displayed.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
