### PR TITLE
Fix type error in faster_eval_api

### DIFF
--- a/faster_coco_eval/core/faster_eval_api.py
+++ b/faster_coco_eval/core/faster_eval_api.py
@@ -235,7 +235,7 @@ class COCOeval_faster(COCOevalBase):
         iou_thrs, rec_thrs = self.params.iouThrs, self.params.recThrs
 
         # Indices for IoU=0.50, first area, and last max dets
-        iou50_idx, area_idx, maxdet_idx = (int(np.argwhere(np.isclose(iou_thrs, 0.50))), 0, -1)
+        iou50_idx, area_idx, maxdet_idx = (np.argwhere(np.isclose(iou_thrs, 0.50)).item(), 0, -1)
         P = self.eval["precision"]
         S = self.eval["scores"]
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fixing #64

## Modification
I changed the cast to integer in faster_eval_api.py:238 to a call to the item function of the ndarray. This retrieves the single value in the 2-dimensional array without resulting in a type error.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
