### PR TITLE
Fix indentation in `unittest.yml` for branch specification

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,7 +2,7 @@ name: Unittests
 
 on:
   push:
-    - branches: [main]
+    branches: [main]
   workflow_call:
 
 jobs:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,6 +3,7 @@ name: Unittests
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_call:
 
 jobs:


### PR DESCRIPTION
This pull request makes a minor correction to the `Unittests` workflow configuration. The change fixes the indentation and formatting of the `branches` specification for the `push` event trigger in `.github/workflows/unittest.yml`.