### PR TITLE
Update pre-commit config to replace `mdformat-black` with `mdformat-ruff`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ htmlcov
 examples/comparison/ultralytics/datasets/*
 examples/profile/baseline.prof
 faster_coco_eval/*.so
+
+# JetBrains IDEs
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: ["--number"]
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-black
+          - mdformat-ruff
           - mdformat_frontmatter
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@
 | **Transparency & Reliability** | Lacks comprehensive testing, making updates risky and results less predictable.             | Emphasizes extensive test coverage and code quality, ensuring trustworthy and reliable results.                                                                                           |
 | **Performance**                | Significantly slower, especially on large datasets or distributed workloads.                | **3-4x faster** due to C++ optimizations and modern algorithms.                                                                                                                           |
 | **Functionality**              | Limited to basic COCO format evaluation.                                                    | Offers extended metrics, support for new IoU types, compatibility with more datasets (e.g., CrowdPose, LVIS), advanced visualizations, and seamless integration with PyTorch/TorchVision. |
-| **Ease of Use**                | Requires manual installation, often with compilation issues.                                 | Simple `pip install`, no compilation required, and drop-in replacement API.                                                                                                               |
-| **Visualization**              | Basic plotting capabilities.                                                                 | Advanced error visualization, annotation display, and comprehensive metric analysis tools.                                                                                               |
+| **Ease of Use**                | Requires manual installation, often with compilation issues.                                | Simple `pip install`, no compilation required, and drop-in replacement API.                                                                                                               |
+| **Visualization**              | Basic plotting capabilities.                                                                | Advanced error visualization, annotation display, and comprehensive metric analysis tools.                                                                                                |
 
----
+______________________________________________________________________
 
 **Key Benefits of Faster-COCO-Eval:**
 
-✅ **Blazing Fast Performance** - Evaluate large datasets in minutes instead of hours  
-✅ **Reliable & Trusted** - Extensive test coverage ensures consistent, reproducible results  
-✅ **Modern Features** - Support for latest CV tasks, IoU types, and dataset formats  
-✅ **Easy to Use** - Drop-in replacement for pycocotools with enhanced API  
-✅ **Comprehensive Visualization** - Understand your model's performance with beautiful, informative plots  
+✅ **Blazing Fast Performance** - Evaluate large datasets in minutes instead of hours
+✅ **Reliable & Trusted** - Extensive test coverage ensures consistent, reproducible results
+✅ **Modern Features** - Support for latest CV tasks, IoU types, and dataset formats
+✅ **Easy to Use** - Drop-in replacement for pycocotools with enhanced API
+✅ **Comprehensive Visualization** - Understand your model's performance with beautiful, informative plots
 
 **Join thousands of computer vision researchers and engineers who have already switched to Faster-COCO-Eval!**
 
@@ -100,8 +100,8 @@ Faster-COCO-Eval is built on top of a highly optimized C++ implementation, provi
 
 Tested on 5000 images from the COCO validation dataset using mmdetection framework:
 
-| Evaluation Type | Faster-COCO-Eval (sec) | pycocotools (sec) | Speedup |
-|-----------------|------------------------|-------------------|---------|
+| Evaluation Type | Faster-COCO-Eval (sec) | pycocotools (sec) | Speedup  |
+| --------------- | ---------------------- | ----------------- | -------- |
 | Bounding Boxes  | 5.812                  | 22.72             | **3.9x** |
 | Segmentation    | 7.413                  | 24.434            | **3.3x** |
 
@@ -119,6 +119,7 @@ See the performance in action:
 Faster-COCO-Eval goes beyond basic evaluation with these advanced capabilities:
 
 ### Core Evaluation
+
 - **Drop-in pycocotools replacement** - No code changes needed
 - **Support for all COCO metric types**: bbox, segm, keypoints
 - **LVIS (Large Vocabulary Instance Segmentation) evaluation**
@@ -126,6 +127,7 @@ Faster-COCO-Eval goes beyond basic evaluation with these advanced capabilities:
 - **Multiple IoU types**: standard, rotated, and custom IoU definitions
 
 ### Advanced Visualization
+
 - **Error visualization**: See where your model is making mistakes
 - **Annotation display**: Visualize ground truth and predictions together
 - **Metric curves**: Precision-recall curves, class-wise performance
@@ -133,12 +135,14 @@ Faster-COCO-Eval goes beyond basic evaluation with these advanced capabilities:
 - **Interactive Jupyter notebook examples**
 
 ### Modern Integrations
+
 - **PyTorch/TorchVision compatibility**
 - **Seamless integration with mmdetection, Detectron2, and YOLO frameworks**
 - **Distributed evaluation support**
 - **Memory optimized for large datasets**
 
 ### Additional Tools
+
 - **Boundary evaluation for segmentation tasks**
 - **Custom dataset support**
 - **Comprehensive API documentation**

--- a/faster_coco_eval/core/faster_eval_api.py
+++ b/faster_coco_eval/core/faster_eval_api.py
@@ -248,14 +248,12 @@ class COCOeval_faster(COCOevalBase):
 
         # --- Compute actual (non-interpolated) precision/recall by sweeping confidence thresholds ---
         # Build set of TP detection IDs: detections matched to a GT with actual IoU >= 0.50
-        tp_dt_ids = {
-            int(k.split("_")[0])
-            for k, iou in self.eval["matched"].items()
-            if iou >= 0.5
-        }
+        tp_dt_ids = {int(k.split("_")[0]) for k, iou in self.eval["matched"].items() if iou >= 0.5}
 
-        cat_ids_eval = self.params.catIds if self.params.useCats else list(
-            {ann["category_id"] for ann in self.cocoDt.anns.values()}
+        cat_ids_eval = (
+            self.params.catIds
+            if self.params.useCats
+            else list({ann["category_id"] for ann in self.cocoDt.anns.values()})
         )
 
         # Per-class: build sorted (descending) score arrays and cumulative TP counts
@@ -319,8 +317,7 @@ class COCOeval_faster(COCOevalBase):
                 macro_precision = float(np.mean(cat_precs))
                 macro_recall = float(np.mean(cat_recs))
                 best_class_metrics = {
-                    cid: {"precision": p, "recall": r}
-                    for cid, p, r in zip(cat_ids_valid, cat_precs, cat_recs)
+                    cid: {"precision": p, "recall": r} for cid, p, r in zip(cat_ids_valid, cat_precs, cat_recs)
                 }
 
         per_class = []

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,25 +5,30 @@ This directory contains the test suite for `faster_coco_eval`, which validates t
 ## Test Organization
 
 ### Core Functionality Tests
+
 - **test_basic.py** - Basic COCO evaluation functionality
 - **test_coco_metric.py** - COCO metrics with pycocotools comparison (small examples)
 - **test_keypoints.py** - Keypoint evaluation
 - **test_cocoapi_fake_data.py** - Tests with synthetic data
 
 ### Extensive Comparison Tests
+
 - **test_extensive_pycocotools_comparison.py** - **NEW**: Comprehensive validation against pycocotools with large synthetic datasets
 
 ### Dataset-Specific Tests
+
 - **test_lvis_metric.py** - LVIS dataset support
 - **test_crowdpose.py** - CrowdPose keypoints dataset
 
 ### API and Integration Tests
+
 - **test_init_pycocotools.py** - Drop-in replacement compatibility
 - **test_torchmetrics.py** - PyTorch integration (if available)
 - **test_mask_api.py** - Mask utilities
 - **test_boundary.py** - Boundary evaluation
 
 ### Visualization and Utilities
+
 - **test_extra_draw.py**, **test_extra_utils.py**, **test_simple_extra.py** - Visualization features
 - **test_ranges.py**, **test_dataset.py** - Utility functions
 
@@ -34,18 +39,23 @@ The `test_extensive_pycocotools_comparison.py` module provides comprehensive val
 ### Test Coverage
 
 #### Object Detection (BBox) Tests
+
 Tests bounding box detection with datasets of varying sizes:
+
 - **Small dataset**: 10 images, 5 categories, ~50 annotations
-- **Medium dataset**: 50 images, 10 categories, ~500 annotations  
+- **Medium dataset**: 50 images, 10 categories, ~500 annotations
 - **Large dataset**: 100 images, 20 categories, ~1500 annotations
 
 Each test validates that both libraries produce identical mAP, mAP@50, mAP@75, and size-specific metrics (small/medium/large objects).
 
 #### Instance Segmentation Tests
+
 Tests segmentation masks with the same dataset size variations as bbox tests. Validates pixel-level mask IoU calculations match exactly between implementations.
 
 #### Keypoint Detection Tests
+
 Tests keypoint pose estimation with datasets containing:
+
 - **Small dataset**: 10 images with 17 keypoints per person
 - **Medium dataset**: 50 images with multiple people per image
 - **Large dataset**: 100 images with varied keypoint visibility
@@ -53,6 +63,7 @@ Tests keypoint pose estimation with datasets containing:
 Validates that OKS (Object Keypoint Similarity) calculations are identical.
 
 #### Edge Cases
+
 - **Perfect predictions**: All predictions match ground truth exactly (IoU=1.0)
 - **Low confidence predictions**: Tests with very low-scoring detections
 - **Mixed object sizes**: Validates correct assignment to small/medium/large categories
@@ -62,7 +73,7 @@ Validates that OKS (Object Keypoint Similarity) calculations are identical.
 The tests use **synthetic but realistic** COCO-formatted datasets that mimic actual model predictions:
 
 - **Varied image sizes**: Random dimensions between 400x400 and 800x800 pixels
-- **Realistic bounding boxes**: Objects categorized as small (<32²), medium (32²-96²), or large (>96²)
+- **Realistic bounding boxes**: Objects categorized as small (\<32²), medium (32²-96²), or large (>96²)
 - **Segmentation masks**: RLE-encoded binary masks matching bbox regions
 - **Keypoint annotations**: 17 keypoints per instance with realistic visibility flags
 - **Prediction noise**: Simulated detection errors with bbox jitter and confidence scores
@@ -71,12 +82,14 @@ The tests use **synthetic but realistic** COCO-formatted datasets that mimic act
 ### Running the Tests
 
 Run all extensive comparison tests:
+
 ```bash
 cd tests/
 pytest test_extensive_pycocotools_comparison.py -v
 ```
 
 Run specific test categories:
+
 ```bash
 # Only bbox tests
 pytest test_extensive_pycocotools_comparison.py -k "bbox" -v
@@ -94,6 +107,7 @@ pytest test_extensive_pycocotools_comparison.py -k "large" -v
 ### Test Success Criteria
 
 Tests pass if and only if:
+
 1. All metrics (mAP, mAP@50, mAP@75, mAP_small, mAP_medium, mAP_large, etc.) are **numerically identical** between `faster_coco_eval` and `pycocotools`
 2. Floating-point comparison uses tolerance of `1e-10` (essentially exact)
 3. All intermediate calculations (IoU, OKS) produce identical results
@@ -111,12 +125,14 @@ These extensive tests address the requirement for **confidence in correctness** 
 ## Running All Tests
 
 Run the complete test suite:
+
 ```bash
 cd tests/
 pytest --cov=faster_coco_eval .
 ```
 
 Run tests for a specific Python version (CI/CD runs Python 3.9-3.13):
+
 ```bash
 pytest --cov=faster_coco_eval . -v
 ```
@@ -124,17 +140,20 @@ pytest --cov=faster_coco_eval . -v
 ## Test Requirements
 
 Install test dependencies:
+
 ```bash
 pip install "faster-coco-eval[tests]"
 ```
 
 Or from source:
+
 ```bash
 cd /path/to/faster_coco_eval
 pip install -e ".[tests]"
 ```
 
 Required packages:
+
 - `pytest` - Test framework
 - `pytest-cov` - Coverage reporting
 - `parameterized` - Parameterized test cases

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -253,6 +253,7 @@ def _contained_box(gt_box, iou):
 @pytest.fixture
 def coco_gt_dt_with_fp():
     """COCO GT/DT pair with two categories:
+
     - cat1: 10 GTs, 10 TPs (conf 0.0–0.9), 0 FPs
     - cat2: 10 GTs, 10 TPs (conf 0.5–0.95), 10 FPs (conf 0.0–0.45)
     """
@@ -264,12 +265,18 @@ def coco_gt_dt_with_fp():
     for i, conf in enumerate([0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]):
         gt = [float(i * _SPACING), 0.0, float(_SIZE), float(_SIZE)]
         anns.append({
-            "id": ann_id, "image_id": image_id, "category_id": 1,
-            "bbox": gt, "area": gt[2] * gt[3], "iscrowd": 0,
+            "id": ann_id,
+            "image_id": image_id,
+            "category_id": 1,
+            "bbox": gt,
+            "area": gt[2] * gt[3],
+            "iscrowd": 0,
         })
         dets.append({
-            "image_id": image_id, "category_id": 1,
-            "bbox": _contained_box(gt, 0.96), "score": conf,
+            "image_id": image_id,
+            "category_id": 1,
+            "bbox": _contained_box(gt, 0.96),
+            "score": conf,
         })
         ann_id += 1
 
@@ -277,19 +284,26 @@ def coco_gt_dt_with_fp():
     for i, conf in enumerate([0.95, 0.90, 0.85, 0.80, 0.75, 0.70, 0.65, 0.60, 0.55, 0.50]):
         gt = [float(i * _SPACING), float(_ROW), float(_SIZE), float(_SIZE)]
         anns.append({
-            "id": ann_id, "image_id": image_id, "category_id": 2,
-            "bbox": gt, "area": gt[2] * gt[3], "iscrowd": 0,
+            "id": ann_id,
+            "image_id": image_id,
+            "category_id": 2,
+            "bbox": gt,
+            "area": gt[2] * gt[3],
+            "iscrowd": 0,
         })
         dets.append({
-            "image_id": image_id, "category_id": 2,
-            "bbox": _contained_box(gt, 0.96), "score": conf,
+            "image_id": image_id,
+            "category_id": 2,
+            "bbox": _contained_box(gt, 0.96),
+            "score": conf,
         })
         ann_id += 1
 
     # cat2 FPs (no GT overlap)
     for i, conf in enumerate([0.45, 0.40, 0.35, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05, 0.00]):
         dets.append({
-            "image_id": image_id, "category_id": 2,
+            "image_id": image_id,
+            "category_id": 2,
             "bbox": [float(i * _SPACING), float(2 * _ROW), float(_SIZE), float(_SIZE)],
             "score": conf,
         })
@@ -324,9 +338,7 @@ def test_extended_metrics_precision_not_overestimated(coco_gt_dt_with_fp):
     assert m["precision"] == pytest.approx(0.75, abs=1e-6), (
         "Macro-precision must not use interpolated (overestimated) values"
     )
-    assert m["recall"] == pytest.approx(1.0, abs=1e-6), (
-        "Macro-recall should be 1.0 at the F1-optimal threshold"
-    )
+    assert m["recall"] == pytest.approx(1.0, abs=1e-6), "Macro-recall should be 1.0 at the F1-optimal threshold"
 
 
 def test_extended_metrics_perfect_predictions():
@@ -336,10 +348,15 @@ def test_extended_metrics_perfect_predictions():
     ann_id = 1
     for i, conf in enumerate([0.9, 0.8, 0.7, 0.6, 0.5]):
         gt = [float(i * _SPACING), 0.0, float(_SIZE), float(_SIZE)]
-        anns.append({"id": ann_id, "image_id": image_id, "category_id": 1,
-                     "bbox": gt, "area": gt[2] * gt[3], "iscrowd": 0})
-        dets.append({"image_id": image_id, "category_id": 1,
-                     "bbox": _contained_box(gt, 0.96), "score": conf})
+        anns.append({
+            "id": ann_id,
+            "image_id": image_id,
+            "category_id": 1,
+            "bbox": gt,
+            "area": gt[2] * gt[3],
+            "iscrowd": 0,
+        })
+        dets.append({"image_id": image_id, "category_id": 1, "bbox": _contained_box(gt, 0.96), "score": conf})
         ann_id += 1
 
     coco_gt = COCO()

--- a/tests/test_extensive_pycocotools_comparison.py
+++ b/tests/test_extensive_pycocotools_comparison.py
@@ -1,13 +1,12 @@
-"""
-Extensive comparison tests between faster_coco_eval and pycocotools.
+"""Extensive comparison tests between faster_coco_eval and pycocotools.
 
-This test suite validates that faster_coco_eval produces identical results to
-pycocotools across a wide range of scenarios with larger, more realistic datasets.
-These tests address the requirement for more extensive validation beyond single examples.
+This test suite validates that faster_coco_eval produces identical
+results to pycocotools across a wide range of scenarios with larger,
+more realistic datasets. These tests address the requirement for more
+extensive validation beyond single examples.
 """
 
 import json
-import os
 import os.path as osp
 import tempfile
 import unittest
@@ -28,12 +27,11 @@ from faster_coco_eval import COCO, COCOeval_faster
 
 
 class TestExtensivePycocotoolsComparison(TestCase):
-    """
-    Extensive test suite comparing faster_coco_eval with pycocotools.
-    
+    """Extensive test suite comparing faster_coco_eval with pycocotools.
+
     Tests multiple scenarios with larger datasets to ensure equality:
     - Object detection (bbox) with many images and annotations
-    - Instance segmentation (segm) with many images and annotations  
+    - Instance segmentation (segm) with many images and annotations
     - Keypoint detection with many images and annotations
     - Various category distributions and object sizes
     - Different score distributions and confidence levels
@@ -53,25 +51,24 @@ class TestExtensivePycocotoolsComparison(TestCase):
         include_segmentation=False,
         include_keypoints=False,
     ):
-        """
-        Create a synthetic COCO dataset with configurable parameters.
-        
+        """Create a synthetic COCO dataset with configurable parameters.
+
         Args:
             num_images: Number of images in the dataset
             num_categories: Number of object categories
             annotations_per_image: Average number of annotations per image
             include_segmentation: Whether to include segmentation masks
             include_keypoints: Whether to include keypoint annotations
-        
+
         Returns:
             Dictionary containing COCO-formatted annotations
         """
         np.random.seed(42)  # For reproducibility
-        
+
         images = []
         annotations = []
         categories = []
-        
+
         # Create categories
         for cat_id in range(num_categories):
             category = {
@@ -84,49 +81,46 @@ class TestExtensivePycocotoolsComparison(TestCase):
                 category["keypoints"] = [f"keypoint_{i}" for i in range(17)]
                 category["skeleton"] = [[i, i + 1] for i in range(0, 16, 2)]
             categories.append(category)
-        
+
         # Create images and annotations
         ann_id = 0
         for img_id in range(num_images):
             # Image dimensions vary
             img_width = np.random.randint(400, 800)
             img_height = np.random.randint(400, 800)
-            
+
             images.append({
                 "id": img_id,
                 "width": img_width,
                 "height": img_height,
                 "file_name": f"image_{img_id:06d}.jpg",
             })
-            
+
             # Variable number of annotations per image
-            num_anns = np.random.randint(
-                max(1, annotations_per_image - 5),
-                annotations_per_image + 5
-            )
-            
+            num_anns = np.random.randint(max(1, annotations_per_image - 5), annotations_per_image + 5)
+
             for _ in range(num_anns):
                 # Random category
                 cat_id = np.random.randint(0, num_categories)
-                
+
                 # Random bbox with various sizes
                 # Create small, medium, and large objects (COCO size categories)
-                size_type = np.random.choice(['small', 'medium', 'large'])
-                if size_type == 'small':
+                size_type = np.random.choice(["small", "medium", "large"])
+                if size_type == "small":
                     w = np.random.randint(10, 32)
                     h = np.random.randint(10, 32)
-                elif size_type == 'medium':
+                elif size_type == "medium":
                     w = np.random.randint(32, 96)
                     h = np.random.randint(32, 96)
                 else:
                     w = np.random.randint(96, min(200, img_width // 2))
                     h = np.random.randint(96, min(200, img_height // 2))
-                
+
                 x = np.random.randint(0, max(1, img_width - w))
                 y = np.random.randint(0, max(1, img_height - h))
-                
+
                 area = w * h
-                
+
                 annotation = {
                     "id": ann_id,
                     "image_id": img_id,
@@ -135,16 +129,16 @@ class TestExtensivePycocotoolsComparison(TestCase):
                     "area": float(area),
                     "iscrowd": 0,
                 }
-                
+
                 if include_segmentation:
                     # Create a simple segmentation mask
                     mask = np.zeros((img_height, img_width), order="F", dtype=np.uint8)
                     # Fill the bounding box region
-                    mask[y:y+h, x:x+w] = 1
+                    mask[y : y + h, x : x + w] = 1
                     rle_mask = mask_util.encode(mask)
                     rle_mask["counts"] = rle_mask["counts"].decode("utf-8")
                     annotation["segmentation"] = rle_mask
-                
+
                 if include_keypoints:
                     # Create random keypoints within the bbox
                     keypoints = []
@@ -163,49 +157,48 @@ class TestExtensivePycocotoolsComparison(TestCase):
                             num_visible += 1
                     annotation["keypoints"] = keypoints
                     annotation["num_keypoints"] = num_visible
-                
+
                 annotations.append(annotation)
                 ann_id += 1
-        
+
         coco_data = {
             "images": images,
             "annotations": annotations,
             "categories": categories,
             "info": {"description": "Synthetic COCO dataset for testing"},
         }
-        
+
         return coco_data
 
     def _create_predictions(self, coco_gt, iou_type="bbox", detection_rate=0.8):
-        """
-        Create synthetic predictions for a COCO dataset.
-        
+        """Create synthetic predictions for a COCO dataset.
+
         Args:
             coco_gt: Ground truth COCO dataset dictionary
             iou_type: Type of predictions ('bbox', 'segm', or 'keypoints')
             detection_rate: Fraction of ground truth objects to detect
-        
+
         Returns:
             List of prediction dictionaries
         """
         np.random.seed(123)  # Different seed for predictions
-        
+
         predictions = []
-        
+
         for ann in coco_gt["annotations"]:
             # Only detect a fraction of objects
             if np.random.random() > detection_rate:
                 continue
-            
+
             pred = {
                 "image_id": ann["image_id"],
                 "category_id": ann["category_id"],
             }
-            
+
             # Add score with some variation
             base_score = np.random.uniform(0.5, 0.99)
             pred["score"] = float(base_score)
-            
+
             if iou_type in ["bbox", "segm"]:
                 # Add some noise to bbox
                 x, y, w, h = ann["bbox"]
@@ -217,24 +210,24 @@ class TestExtensivePycocotoolsComparison(TestCase):
                     float(h * noise_factor),
                 ]
                 pred["area"] = float(pred["bbox"][2] * pred["bbox"][3])
-            
+
             if iou_type == "segm" and "segmentation" in ann:
                 # Use ground truth segmentation with slight modification
                 pred["segmentation"] = ann["segmentation"]
-            
+
             if iou_type == "keypoints" and "keypoints" in ann:
                 # Add noise to keypoint locations
                 keypoints = []
                 for i in range(0, len(ann["keypoints"]), 3):
-                    kp_x, kp_y, v = ann["keypoints"][i:i+3]
+                    kp_x, kp_y, v = ann["keypoints"][i : i + 3]
                     if v > 0:
                         kp_x += np.random.uniform(-3, 3)
                         kp_y += np.random.uniform(-3, 3)
                     keypoints.extend([float(kp_x), float(kp_y), v])
                 pred["keypoints"] = keypoints
-            
+
             predictions.append(pred)
-        
+
         # Add some false positives
         num_false_positives = int(len(predictions) * 0.1)
         for img in coco_gt["images"][:num_false_positives]:
@@ -243,7 +236,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
                 "category_id": np.random.randint(0, len(coco_gt["categories"])),
                 "score": float(np.random.uniform(0.3, 0.7)),
             }
-            
+
             if iou_type in ["bbox", "segm"]:
                 w = np.random.randint(20, 100)
                 h = np.random.randint(20, 100)
@@ -251,15 +244,15 @@ class TestExtensivePycocotoolsComparison(TestCase):
                 y = np.random.randint(0, max(1, img["height"] - h))
                 pred["bbox"] = [float(x), float(y), float(w), float(h)]
                 pred["area"] = float(w * h)
-            
+
             if iou_type == "segm":
                 # Create a dummy mask
                 mask = np.zeros((img["height"], img["width"]), order="F", dtype=np.uint8)
-                mask[y:y+h, x:x+w] = 1
+                mask[y : y + h, x : x + w] = 1
                 rle_mask = mask_util.encode(mask)
                 rle_mask["counts"] = rle_mask["counts"].decode("utf-8")
                 pred["segmentation"] = rle_mask
-            
+
             if iou_type == "keypoints":
                 # Create dummy keypoints
                 keypoints = []
@@ -267,24 +260,23 @@ class TestExtensivePycocotoolsComparison(TestCase):
                     keypoints.extend([
                         float(np.random.randint(0, img["width"])),
                         float(np.random.randint(0, img["height"])),
-                        2
+                        2,
                     ])
                 pred["keypoints"] = keypoints
-            
+
             predictions.append(pred)
-        
+
         return predictions
 
     def _compare_evaluators(self, gt_file, predictions, iou_type, tolerance=1e-10):
-        """
-        Compare results from faster_coco_eval and pycocotools.
-        
+        """Compare results from faster_coco_eval and pycocotools.
+
         Args:
             gt_file: Path to ground truth JSON file
             predictions: List of prediction dictionaries
             iou_type: Type of evaluation ('bbox', 'segm', or 'keypoints')
             tolerance: Tolerance for floating point comparison
-        
+
         Returns:
             Tuple[np.ndarray, np.ndarray, bool]: A tuple containing:
                 - faster_coco_eval stats array
@@ -298,7 +290,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
         coco_eval_fast.evaluate()
         coco_eval_fast.accumulate()
         coco_eval_fast.summarize()
-        
+
         # Evaluate with pycocotools
         coco_gt_orig = origCOCO(gt_file)
         coco_dt_orig = coco_gt_orig.loadRes(predictions)
@@ -306,14 +298,14 @@ class TestExtensivePycocotoolsComparison(TestCase):
         coco_eval_orig.evaluate()
         coco_eval_orig.accumulate()
         coco_eval_orig.summarize()
-        
+
         # Compare stats
         fast_stats = coco_eval_fast.stats
         orig_stats = coco_eval_orig.stats
-        
+
         # Check if stats are equal within tolerance
         are_equal = np.allclose(fast_stats, orig_stats, rtol=tolerance, atol=tolerance)
-        
+
         return fast_stats, orig_stats, are_equal
 
     @parameterized.expand([
@@ -325,7 +317,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
         """Test bbox detection with various dataset sizes."""
         if origCOCO is None:
             raise unittest.SkipTest("pycocotools not available")
-        
+
         # Create dataset
         coco_data = self._create_coco_annotations(
             num_images=num_images,
@@ -334,19 +326,17 @@ class TestExtensivePycocotoolsComparison(TestCase):
             include_segmentation=False,
             include_keypoints=False,
         )
-        
+
         gt_file = osp.join(self.tmp_dir.name, f"gt_{name}.json")
         with open(gt_file, "w") as f:
             json.dump(coco_data, f)
-        
+
         # Create predictions
         predictions = self._create_predictions(coco_data, iou_type="bbox")
-        
+
         # Compare evaluators
-        fast_stats, orig_stats, are_equal = self._compare_evaluators(
-            gt_file, predictions, "bbox"
-        )
-        
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, "bbox")
+
         # Assert equality
         self.assertTrue(
             are_equal,
@@ -354,7 +344,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
             f"{len(predictions)} predictions)\n"
             f"faster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
-            f"Difference: {fast_stats - orig_stats}"
+            f"Difference: {fast_stats - orig_stats}",
         )
 
     @parameterized.expand([
@@ -366,7 +356,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
         """Test instance segmentation with various dataset sizes."""
         if origCOCO is None:
             raise unittest.SkipTest("pycocotools not available")
-        
+
         # Create dataset with segmentation
         coco_data = self._create_coco_annotations(
             num_images=num_images,
@@ -375,19 +365,17 @@ class TestExtensivePycocotoolsComparison(TestCase):
             include_segmentation=True,
             include_keypoints=False,
         )
-        
+
         gt_file = osp.join(self.tmp_dir.name, f"gt_{name}_segm.json")
         with open(gt_file, "w") as f:
             json.dump(coco_data, f)
-        
+
         # Create predictions
         predictions = self._create_predictions(coco_data, iou_type="segm")
-        
+
         # Compare evaluators
-        fast_stats, orig_stats, are_equal = self._compare_evaluators(
-            gt_file, predictions, "segm"
-        )
-        
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, "segm")
+
         # Assert equality
         self.assertTrue(
             are_equal,
@@ -395,7 +383,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
             f"{len(predictions)} predictions)\n"
             f"faster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
-            f"Difference: {fast_stats - orig_stats}"
+            f"Difference: {fast_stats - orig_stats}",
         )
 
     @parameterized.expand([
@@ -407,7 +395,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
         """Test keypoint detection with various dataset sizes."""
         if origCOCO is None:
             raise unittest.SkipTest("pycocotools not available")
-        
+
         # Create dataset with keypoints
         coco_data = self._create_coco_annotations(
             num_images=num_images,
@@ -416,19 +404,17 @@ class TestExtensivePycocotoolsComparison(TestCase):
             include_segmentation=False,
             include_keypoints=True,
         )
-        
+
         gt_file = osp.join(self.tmp_dir.name, f"gt_{name}_kpts.json")
         with open(gt_file, "w") as f:
             json.dump(coco_data, f)
-        
+
         # Create predictions
         predictions = self._create_predictions(coco_data, iou_type="keypoints")
-        
+
         # Compare evaluators
-        fast_stats, orig_stats, are_equal = self._compare_evaluators(
-            gt_file, predictions, "keypoints"
-        )
-        
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, "keypoints")
+
         # Assert equality
         self.assertTrue(
             are_equal,
@@ -436,12 +422,12 @@ class TestExtensivePycocotoolsComparison(TestCase):
             f"{len(predictions)} predictions)\n"
             f"faster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
-            f"Difference: {fast_stats - orig_stats}"
+            f"Difference: {fast_stats - orig_stats}",
         )
 
     def test_edge_case_no_predictions(self):
         """Test evaluation with no predictions.
-        
+
         Note: Both pycocotools and faster_coco_eval have issues with truly empty
         prediction lists (loadRes() fails on empty lists when trying to inspect the
         first element to determine annotation type). This is a known limitation in
@@ -450,57 +436,57 @@ class TestExtensivePycocotoolsComparison(TestCase):
         """
         if origCOCO is None:
             raise unittest.SkipTest("pycocotools not available")
-        
+
         # Create dataset
         coco_data = self._create_coco_annotations(
             num_images=10,
             num_categories=5,
             annotations_per_image=5,
         )
-        
+
         gt_file = osp.join(self.tmp_dir.name, "gt_no_preds.json")
         with open(gt_file, "w") as f:
             json.dump(coco_data, f)
-        
+
         # Use a very low score prediction instead of empty list
         # (Both APIs crash on truly empty prediction lists)
-        predictions = [{
-            "image_id": coco_data["images"][0]["id"],
-            "category_id": 0,
-            "bbox": [10.0, 10.0, 10.0, 10.0],
-            "area": 100.0,
-            "score": 0.01,  # Very low score to simulate near-empty results
-        }]
-        
+        predictions = [
+            {
+                "image_id": coco_data["images"][0]["id"],
+                "category_id": 0,
+                "bbox": [10.0, 10.0, 10.0, 10.0],
+                "area": 100.0,
+                "score": 0.01,  # Very low score to simulate near-empty results
+            }
+        ]
+
         # Compare evaluators
-        fast_stats, orig_stats, are_equal = self._compare_evaluators(
-            gt_file, predictions, "bbox"
-        )
-        
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, "bbox")
+
         # Assert equality
         self.assertTrue(
             are_equal,
             f"\nfaster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
-            f"Difference: {fast_stats - orig_stats}"
+            f"Difference: {fast_stats - orig_stats}",
         )
 
     def test_edge_case_perfect_predictions(self):
         """Test evaluation with perfect predictions (all IOU=1.0)."""
         if origCOCO is None:
             raise unittest.SkipTest("pycocotools not available")
-        
+
         # Create small dataset
         coco_data = self._create_coco_annotations(
             num_images=10,
             num_categories=3,
             annotations_per_image=5,
         )
-        
+
         gt_file = osp.join(self.tmp_dir.name, "gt_perfect.json")
         with open(gt_file, "w") as f:
             json.dump(coco_data, f)
-        
+
         # Create perfect predictions (identical to ground truth)
         predictions = []
         for ann in coco_data["annotations"]:
@@ -512,52 +498,48 @@ class TestExtensivePycocotoolsComparison(TestCase):
                 "score": 1.0,
             }
             predictions.append(pred)
-        
+
         # Compare evaluators
-        fast_stats, orig_stats, are_equal = self._compare_evaluators(
-            gt_file, predictions, "bbox"
-        )
-        
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, "bbox")
+
         # Assert equality
         self.assertTrue(
             are_equal,
             f"\nfaster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
-            f"Difference: {fast_stats - orig_stats}"
+            f"Difference: {fast_stats - orig_stats}",
         )
 
     def test_mixed_object_sizes(self):
         """Test evaluation with mixed small/medium/large objects."""
         if origCOCO is None:
             raise unittest.SkipTest("pycocotools not available")
-        
+
         # Create dataset with controlled object sizes
         coco_data = self._create_coco_annotations(
             num_images=50,
             num_categories=10,
             annotations_per_image=15,
         )
-        
+
         gt_file = osp.join(self.tmp_dir.name, "gt_mixed_sizes.json")
         with open(gt_file, "w") as f:
             json.dump(coco_data, f)
-        
+
         # Create predictions
         predictions = self._create_predictions(coco_data, iou_type="bbox")
-        
+
         # Compare evaluators
-        fast_stats, orig_stats, are_equal = self._compare_evaluators(
-            gt_file, predictions, "bbox"
-        )
-        
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, "bbox")
+
         # Assert equality
         self.assertTrue(
             are_equal,
             f"\nfaster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
-            f"Difference: {fast_stats - orig_stats}"
+            f"Difference: {fast_stats - orig_stats}",
         )
-        
+
         # Also verify that we have metrics for different size categories
         # Stats indices: [mAP, mAP@50, mAP@75, mAP_small, mAP_medium, mAP_large, ...]
         self.assertGreaterEqual(len(fast_stats), 6)

--- a/tests/test_simple_extra.py
+++ b/tests/test_simple_extra.py
@@ -192,9 +192,7 @@ def _make_coco_eval(iou_thrs=None):
     coco_gt.createIndex()
 
     pred_bbox = [10.0, 10.0, float(SIZE - 20), float(SIZE - 20)]
-    coco_dt = coco_gt.loadRes([
-        {"image_id": image_id, "category_id": 1, "bbox": pred_bbox, "score": 0.9}
-    ])
+    coco_dt = coco_gt.loadRes([{"image_id": image_id, "category_id": 1, "bbox": pred_bbox, "score": 0.9}])
 
     coco_eval = COCOeval_faster(coco_gt, coco_dt, iouType="bbox")
     if iou_thrs is not None:
@@ -206,7 +204,8 @@ def _make_coco_eval(iou_thrs=None):
 
 
 def test_extended_metrics_raises_when_iou50_missing():
-    """extended_metrics must raise ValueError when 0.50 is absent from iouThrs."""
+    """extended_metrics must raise ValueError when 0.50 is absent from
+    iouThrs."""
     coco_eval = _make_coco_eval(iou_thrs=[0.55, 0.65, 0.75, 0.85, 0.95])
     with pytest.raises(ValueError, match="0.50"):
         _ = coco_eval.extended_metrics


### PR DESCRIPTION
This pull request updates the pre-commit configuration to use a different Markdown formatting dependency. The change replaces `mdformat-black` with `mdformat-ruff` in the list of additional dependencies for the Markdown formatting hook.

Dependency update:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L38-R38): Replaced `mdformat-black` with `mdformat-ruff` in the `mdformat` hook dependencies to align with updated formatting requirements.