### PR TITLE
fix(coco): warn on annotation id 0 ambiguous match sentinel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ examples/comparison/ultralytics/runs/*
 examples/comparison/ultralytics/*.pt
 *.whl
 *.pyd
-tests/.coverage
 .coverage
 docs/source/examples/*.ipynb
 .ruff_cache
@@ -25,3 +24,9 @@ faster_coco_eval/*.so
 
 # JetBrains IDEs
 .idea/
+
+# AI assistant files
+.cache/
+.claude/
+.plans/
+.temp/

--- a/faster_coco_eval/core/coco.py
+++ b/faster_coco_eval/core/coco.py
@@ -119,15 +119,8 @@ class COCO:
                     anns[ann["id"]] = ann
 
             if 0 in anns:
-                warnings.warn(
-                    "Found annotation id 0. Annotation ids are used as match "
-                    "markers during evaluation, where 0 also means 'unmatched' — "
-                    "an annotation with id 0 cannot be distinguished from an "
-                    "unmatched one, silently skewing precision/recall. Consider "
-                    "using 1-indexed annotation ids.",
                     UserWarning,
-                    stacklevel=2,
-                )
+                    stacklevel=3,
 
         if "categories" in self.dataset:
             for cat in self.dataset["categories"]:

--- a/faster_coco_eval/core/coco.py
+++ b/faster_coco_eval/core/coco.py
@@ -119,8 +119,15 @@ class COCO:
                     anns[ann["id"]] = ann
 
             if 0 in anns:
+                warnings.warn(
+                    "Found annotation id 0. Annotation ids are used as match "
+                    "markers during evaluation, where 0 also means 'unmatched' — "
+                    "an annotation with id 0 cannot be distinguished from an "
+                    "unmatched one, silently skewing precision/recall. Consider "
+                    "using 1-indexed annotation ids.",
                     UserWarning,
                     stacklevel=3,
+                )
 
         if "categories" in self.dataset:
             for cat in self.dataset["categories"]:

--- a/faster_coco_eval/core/coco.py
+++ b/faster_coco_eval/core/coco.py
@@ -118,6 +118,17 @@ class COCO:
                     imgToAnns[ann["image_id"]].append(ann)
                     anns[ann["id"]] = ann
 
+            if 0 in anns:
+                warnings.warn(
+                    "Found annotation id 0. Annotation ids are used as match "
+                    "markers during evaluation, where 0 also means 'unmatched' — "
+                    "an annotation with id 0 cannot be distinguished from an "
+                    "unmatched one, silently skewing precision/recall. Consider "
+                    "using 1-indexed annotation ids.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         if "categories" in self.dataset:
             for cat in self.dataset["categories"]:
                 cats[cat["id"]] = cat

--- a/tests/test_annotation_id_zero.py
+++ b/tests/test_annotation_id_zero.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+import unittest
+import warnings
+
+from faster_coco_eval import COCO
+
+
+class TestAnnotationIdZero(unittest.TestCase):
+    """Regression test for #77 — gt/dt annotation id=0 collides with the
+    internal "no match" sentinel used during evaluation matching, silently
+    miscounting that annotation as unmatched.
+
+    createIndex() should warn.
+    """
+
+    def _dataset(self, ann_ids):
+        """Build a minimal single-image dataset with the given annotation
+        ids."""
+        return {
+            "images": [{"id": 1, "width": 100, "height": 100}],
+            "categories": [{"id": 1, "name": "x"}],
+            "annotations": [
+                {
+                    "id": ann_id,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "bbox": [0, 0, 10, 10],
+                    "area": 100,
+                    "iscrowd": 0,
+                }
+                for ann_id in ann_ids
+            ],
+        }
+
+    def test_warns_when_annotation_id_zero_present(self):
+        """CreateIndex() warns when a dataset contains annotation id 0."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            COCO(self._dataset([0, 1]))
+
+        self.assertTrue(
+            any("id 0" in str(w.message) or "id=0" in str(w.message) for w in caught),
+            f"expected a warning about annotation id 0, got: {[str(w.message) for w in caught]}",
+        )
+
+    def test_no_warning_when_ids_start_from_one(self):
+        """CreateIndex() stays silent when no annotation id is 0."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            COCO(self._dataset([1, 2]))
+
+        self.assertEqual(caught, [], f"unexpected warnings: {[str(w.message) for w in caught]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation                                                                                                                               
                                                                                                                                              
Issue #77: `pycocotools`-style matching stores the ground-truth/detection annotation `id` directly in the `dtMatches`/`gtMatches` arrays, using `0` as the "unmatched" sentinel. An annotation with `id == 0` is indistinguishable from "no match" — silently miscounted as FN/FP, skewing precision/recall on datasets with 0-indexed ids. Changing the matching logic itself would break `pycocotools` compatibility, so this PR keeps the 0-sentinel and warns instead.                                                                                                  
                                                                                                                                            
## Modification                                                                                                                             
                                                                                                                                            
- `COCO.createIndex()` emits `UserWarning` when loaded dataset (gt or dt) contains an annotation with `id == 0`.                            
- Added `tests/test_annotation_id_zero.py` — warning fires on id 0, silent when ids start from 1.                                           
                                                                                                                                            
## BC-breaking (Optional)                                                                                                                   
                                                                                                                                            
None. No matching/scoring behavior changed — only a new `UserWarning` emitted.                                                              
                                                                                                                                            
## Use cases (Optional)                                                                                                                     
                                                                                                                                            
N/A — not a new feature.                                                                                                                    
                                                                                                                                            
## Checklist                                                                                                                                
                                                                                                                                            
1. `ruff check` / `ruff format` clean on changed files.                                                                                     
2. New test file (2 cases); full suite (103 passed, 3 skipped) + impacted-file set (82 passed) verified, no regressions.                    
3. Downstream testing n/a — no matching/scoring behavior changed.                                                                           
4. Docs n/a — warning message self-explanatory at call time.