### PR TITLE
fix(api): correct rleIou mismatch indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ faster_coco_eval/*.so
 
 # AI assistant files
 .cache/
+.junie/
 .claude/
+.developments/
 .plans/
+.reports/
 .temp/

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -458,7 +458,7 @@ std::vector<double> rleIou(const std::vector<RLE>& dt,
                         if (o[d * n + g] > 0) {
                                 crowd = _iscrowd && iscrowd[g];
                                 if (dt[d].h != gt[g].h || dt[d].w != gt[g].w) {
-                                        o[g * n + d] = -1;
+                                        o[d * n + g] = -1;
                                         continue;
                                 }
                                 uint64_t ka, kb, a, b, c, ca, cb, ct, i, u;

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -188,6 +188,27 @@ class TestMaskApi(unittest.TestCase):
         result_poly_iou = module.iou(self.poly_rles[:3], self.poly_rles[:3], [0, 0, 0]).round(4)
         self.assertEqual(poly_iou.tolist(), result_poly_iou.tolist())
 
+    def test_iou_size_mismatch_writes_sentinel_to_pair(self):
+        """Return -1 in each pair's output cell when RLE sizes differ."""
+        dt = _mask.frBbox([[0, 0, 2, 2]], 4, 4) * 2
+        gt = [
+            _mask.frBbox([[0, 0, 2, 2]], 4, 4)[0],
+            _mask.frBbox([[0, 0, 2, 2]], 5, 5)[0],
+        ]
+
+        result = _mask.iou(dt, gt, [0, 0])
+
+        np.testing.assert_array_equal(result, [[1.0, -1.0], [1.0, -1.0]])
+
+    def test_iou_size_mismatch_rectangular_output_stays_in_bounds(self):
+        """Return one sentinel per mismatched pair for a rectangular result."""
+        dt = _mask.frBbox([[0, 0, 2, 2]], 4, 4)
+        gt = _mask.frBbox([[0, 0, 2, 2]] * 5, 5, 5)
+
+        result = _mask.iou(dt, gt, [0] * 5)
+
+        np.testing.assert_array_equal(result, np.full((1, 5), -1.0))
+
     def testToBboxFullImage(self):
         mask = np.array([[0, 1], [1, 1]])
         bbox = mask_util.toBbox(_encode(mask))


### PR DESCRIPTION
## Motivation

Fix C-1 from the Fable review tracked by issue #80. When `rleIou` receives detection and ground-truth RLEs with different sizes, the size-mismatch branch writes the sentinel to the wrong output cell and can write past the heap for rectangular outputs.

## Modification

Correct the mismatch-branch index from `o[g * n + d]` to `o[d * n + g]` in `rleIou`. Add regression tests covering mixed-size square output and a rectangular `1 x 5` output.

Verification:

- `25 passed` in `tests/test_mask_api.py`.
- Ruff, formatting, pre-commit, clang-format, diff review, and artifact validation passed.

## BC-breaking (Optional)

No. This fixes incorrect behavior and preserves the existing public API and `-1` sentinel contract for mismatched RLE sizes.

## Use cases (Optional)

This protects callers comparing masks from different image sizes, including rectangular detection/ground-truth pair matrices.

## Checklist

1. Pre-commit and other linting tools were run successfully.
2. The modification is covered by focused unit tests and the full `tests/test_mask_api.py` module passes.
3. Downstream-project testing is not applicable to this narrow internal indexing fix.
4. Documentation changes are not applicable.
