### PR TITLE
ci(tests): run optional dependency integrations

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,3 +32,36 @@ jobs:
         working-directory: ./tests
         run: |
           pytest --cov=faster_coco_eval .
+
+  optional-dependency-tests:
+    name: Optional dependency tests (ubuntu-latest, Python 3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install optional test dependencies from sdist
+        shell: bash
+        run: |
+          pipx run build --sdist .
+          source_file=$(ls ./dist/*.tar.gz)
+          python -m pip install "${source_file}[tests,extra]"
+          python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install torchmetrics lightning-utilities
+          python -m pip check
+
+      - name: Assert optional test collection
+        shell: bash
+        working-directory: ./tests
+        run: |
+          set -euo pipefail
+          for test_file in test_torchmetrics.py test_world_evalutor.py test_extra_draw.py; do
+            python -m pytest --collect-only -q "$test_file"
+          done
+
+      - name: Run optional dependency tests
+        working-directory: ./tests
+        run: |
+          python -m pytest -q test_torchmetrics.py test_world_evalutor.py test_extra_draw.py

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |
           pipx run build --sdist .
-          source_file=$(ls ./dist/*.tar.gz)
+          source_file=$(python -c "import glob,sys; files=glob.glob('dist/*.tar.gz'); (len(files)==1) or sys.exit(f'Expected 1 sdist in dist/, found {len(files)}: {files}'); print(files[0])")
           python -m pip install "${source_file}[tests,extra]"
           python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           python -m pip install torchmetrics lightning-utilities

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -52,13 +52,13 @@ jobs:
           python -m pip install torchmetrics lightning-utilities
           python -m pip check
 
-      - name: Assert optional test collection
+      - name: Assert optional test modules import (no SkipTest)
         shell: bash
         working-directory: ./tests
         run: |
           set -euo pipefail
           for test_file in test_torchmetrics.py test_world_evalutor.py test_extra_draw.py; do
-            python -m pytest --collect-only -q "$test_file"
+            python -c "import runpy; runpy.run_path('${test_file}')"
           done
 
       - name: Run optional dependency tests


### PR DESCRIPTION
## Motivation

Resolve review finding C-2 and reference issue #80. CI installed neither the visualization stack nor PyTorch integration dependencies, so three optional-dependency test modules skipped at import time.

## Modification

Add one Ubuntu Python 3.11 sdist job to `unittest.yml`. It installs `[tests,extra]`, CPU torch and torchvision, torchmetrics, and lightning-utilities; runs `pip check`; individually collects each target module before running the three-file subset from `tests/`.

## BC-breaking (Optional)

No public API or package dependency change. CI duration increases by one CPU PyTorch job.

## Use cases (Optional)

The lane executes the FasterCocoEvaluator/torchmetrics, distributed evaluator, and Plotly/Pillow draw integrations that prior CI lanes silently skipped.

## Checklist

1. Ruff lint and format checks pass.
2. YAML/static workflow contract passes. Live CPU-wheel installation and GitHub execution remain pending the next CI run.
3. No downstream behavior changes.
4. No public documentation change is required.

Known follow-up: H-6 fixed-port process-group cleanup remains outside C-2 scope.