### PR TITLE
fix(api): retain orphan annotations in indexes

### DIFF
--- a/faster_coco_eval/core/coco.py
+++ b/faster_coco_eval/core/coco.py
@@ -100,23 +100,20 @@ class COCO:
         anns, cats, imgs = {}, {}, {}
         imgToAnns, catToImgs = defaultdict(list), defaultdict(list)
 
-        annsImgIds_dict = set()
         if "images" in self.dataset:
             for img in self.dataset["images"]:
                 if type(img["id"]) is not int:
                     img["id"] = int(img["id"])
 
                 imgs[img["id"]] = img
-                annsImgIds_dict.add(img["id"])
 
         if "annotations" in self.dataset:
             for ann in self.dataset["annotations"]:
                 if type(ann["image_id"]) is not int:
                     ann["image_id"] = int(ann["image_id"])
 
-                if ann["image_id"] in annsImgIds_dict:
-                    imgToAnns[ann["image_id"]].append(ann)
-                    anns[ann["id"]] = ann
+                imgToAnns[ann["image_id"]].append(ann)
+                anns[ann["id"]] = ann
 
             if 0 in anns:
                 warnings.warn(

--- a/tests/test_orphan_annotations.py
+++ b/tests/test_orphan_annotations.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+import unittest
+
+from faster_coco_eval import COCO
+
+
+class TestOrphanAnnotations(unittest.TestCase):
+    """Verify annotations remain consistently indexed without image metadata."""
+
+    def test_orphan_annotation_is_available_from_every_annotation_index(self):
+        """Keep orphan annotations loadable and discoverable by category."""
+        annotation = {
+            "id": 7,
+            "image_id": 99,
+            "category_id": 3,
+            "bbox": [0, 0, 1, 1],
+            "area": 1,
+            "iscrowd": 0,
+        }
+        coco = COCO({
+            "images": [],
+            "categories": [{"id": 3, "name": "thing"}],
+            "annotations": [annotation],
+        })
+
+        annotation_ids = coco.getAnnIds()
+
+        self.assertEqual(annotation_ids, [annotation["id"]])
+        self.assertEqual(coco.loadAnns(annotation_ids), [annotation])
+        self.assertEqual(coco.imgToAnns[annotation["image_id"]], [annotation])
+        self.assertEqual(coco.catToImgs[annotation["category_id"]], [annotation["image_id"]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request improves how orphan annotations (annotations without corresponding image metadata) are handled and tested in the COCO evaluation codebase. The main change removes a check that previously excluded such annotations from being indexed, ensuring all annotations are consistently available. A new test is also added to confirm this behavior.

**Annotation indexing improvements:**

* Removed the restriction in `coco.py` that only indexed annotations if their `image_id` existed in the images metadata, allowing orphan annotations to be included in all annotation indexes.

**Testing enhancements:**

* Added `tests/test_orphan_annotations.py` to verify that orphan annotations are correctly indexed and accessible from all relevant annotation indexes, even when no image metadata is present.

---

part of #80