### PR TITLE
fix(mask): guard decoded RLE slices

### DIFF
--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -241,7 +241,7 @@ py::array_t<uint8_t, py::array::f_style> rleDecode(const std::vector<RLE>& R) {
         uint64_t h = R[0].h;
         uint64_t w = R[0].w;
         size_t n = R.size();
-        uint64_t s = h * w * n;
+        uint64_t pixels_per_mask = h * w;
 
         py::array_t<uint8_t, py::array::f_style> M(
             {static_cast<size_t>(h), static_cast<size_t>(w), n});
@@ -253,7 +253,7 @@ py::array_t<uint8_t, py::array::f_style> rleDecode(const std::vector<RLE>& R) {
 
                 for (uint64_t j = 0; j < R[i].m; ++j) {
                         for (uint64_t k = 0; k < R[i].cnts[j]; ++k) {
-                                if (c >= s) {
+                                if (c >= pixels_per_mask) {
                                         std::stringstream ss;
                                         ss << "Invalid RLE mask "
                                               "representation; out of range "

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -273,6 +273,13 @@ py::array_t<uint8_t, py::array::f_style> rleDecode(const std::vector<RLE>& R) {
                         }
                         v = !v;
                 }
+                if (c != pixels_per_mask) {
+                        std::stringstream ss;
+                        ss << "Invalid RLE mask representation; decoded " << c
+                           << " pixels but expected " << pixels_per_mask
+                           << " (h=" << h << ", w=" << w << ")";
+                        throw std::range_error(ss.str());
+                }
         }
         return M;
 }

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -125,6 +125,16 @@ class TestMaskApi(unittest.TestCase):
         with self.assertRaises(ValueError):
             _mask.decode([valid, oversized])
 
+    def test_decode_rejects_count_smaller_than_mask(self):
+        """Reject a second RLE whose runs sum to fewer pixels than h*w."""
+        valid, undersized = _mask.frUncompressedRLE([
+            {"size": [2, 2], "counts": [0, 4]},
+            {"size": [2, 2], "counts": [0, 3]},
+        ])
+
+        with self.assertRaises(ValueError):
+            _mask.decode([valid, undersized])
+
     def test_frBbox(self):
         self.assertEqual(self.bbox_rles, _mask.frBbox(self.bboxes, 20, 20))
 

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -115,6 +115,16 @@ class TestMaskApi(unittest.TestCase):
     def test_rles(self):
         self.assertTrue(np.all([_mask.encode(_mask.decode([rle])) == [rle] for rle in self.rleObjs]))
 
+    def test_decode_rejects_count_larger_than_each_mask(self):
+        """Reject a second RLE whose runs exceed its own mask dimensions."""
+        valid, oversized = _mask.frUncompressedRLE([
+            {"size": [2, 2], "counts": [0, 4]},
+            {"size": [2, 2], "counts": [0, 5]},
+        ])
+
+        with self.assertRaises(ValueError):
+            _mask.decode([valid, oversized])
+
     def test_frBbox(self):
         self.assertEqual(self.bbox_rles, _mask.frBbox(self.bboxes, 20, 20))
 


### PR DESCRIPTION
This pull request improves the robustness of the RLE mask decoding logic and adds a corresponding test to ensure that invalid masks are properly rejected. The main changes include correcting the bounds checking in the decoder and adding a unit test for oversized RLE counts.

**Bug Fixes and Robustness Improvements:**

* Updated `rleDecode` in `mask.cpp` to use `pixels_per_mask` for bounds checking, ensuring that each mask's pixel count is validated against its own dimensions rather than the total across all masks. [[1]](diffhunk://#diff-8e664d578574d7ecb2472b5af8bfa2d557c238d55d770a1c75b7215f7c1f3303L244-R244) [[2]](diffhunk://#diff-8e664d578574d7ecb2472b5af8bfa2d557c238d55d770a1c75b7215f7c1f3303L256-R256)

**Testing:**

* Added `test_decode_rejects_count_larger_than_each_mask` to `test_mask_api.py` to verify that decoding fails when an RLE's run counts exceed its mask dimensions, raising a `ValueError` as expected.

---

part of #80