### PR TITLE
fix(utils): support gloo all gather

### DIFF
--- a/faster_coco_eval/utils/pytorch/coco_eval.py
+++ b/faster_coco_eval/utils/pytorch/coco_eval.py
@@ -331,14 +331,17 @@ def all_gather(data: Any, world_size: int = None) -> List[Any]:
     if world_size == 1:
         return [data]
 
+    # Gloo and other non-NCCL backends only support CPU tensors.
+    device = torch.device("cuda") if dist.get_backend() == "nccl" else torch.device("cpu")
+
     # serialized to a Tensor
     buffer = pickle.dumps(data)
     byte_array = bytearray(buffer)
-    tensor = torch.ByteTensor(list(byte_array)).to("cuda")
+    tensor = torch.tensor(byte_array, dtype=torch.uint8, device=device)
 
     # obtain Tensor size of each rank
-    local_size = torch.tensor([tensor.numel()], device="cuda")
-    size_list = [torch.tensor([0], device="cuda") for _ in range(world_size)]
+    local_size = torch.tensor([tensor.numel()], device=device)
+    size_list = [torch.tensor([0], device=device) for _ in range(world_size)]
     dist.all_gather(size_list, local_size)
     size_list = [int(size.item()) for size in size_list]
     max_size = max(size_list)
@@ -348,9 +351,9 @@ def all_gather(data: Any, world_size: int = None) -> List[Any]:
     # gathering tensors of different shapes
     tensor_list = []
     for _ in size_list:
-        tensor_list.append(torch.empty((max_size,), dtype=torch.uint8, device="cuda"))
-    if local_size != max_size:
-        padding = torch.empty(size=(max_size - local_size,), dtype=torch.uint8, device="cuda")
+        tensor_list.append(torch.empty((max_size,), dtype=torch.uint8, device=device))
+    if local_size.item() != max_size:
+        padding = torch.empty(size=(max_size - local_size.item(),), dtype=torch.uint8, device=device)
         tensor = torch.cat((tensor, padding), dim=0)
     dist.all_gather(tensor_list, tensor)
 

--- a/tests/test_pytorch_coco_eval.py
+++ b/tests/test_pytorch_coco_eval.py
@@ -1,0 +1,67 @@
+"""Regression coverage for PyTorch distributed evaluation helpers."""
+
+import multiprocessing
+import os
+import sys
+import tempfile
+import unittest
+
+try:
+    import torch.distributed as dist
+except ImportError:
+    raise unittest.SkipTest("Skipping PyTorch distributed tests because torch is unavailable.")
+
+from faster_coco_eval.utils.pytorch.coco_eval import all_gather
+
+
+def _all_gather_worker(rank, init_file, results):
+    """Gather a rank-specific payload through a two-rank gloo group."""
+    dist.init_process_group("gloo", rank=rank, world_size=2, init_method=f"file://{init_file}")
+    try:
+        results.put(all_gather({"rank": rank, "payload": "x" * (rank + 1)}))
+    finally:
+        dist.destroy_process_group()
+
+
+class TestAllGather(unittest.TestCase):
+    """Test distributed collection of picklable evaluator data."""
+
+    def test_gloo_gathers_unequal_cpu_payloads(self):
+        """Gather unequal payloads without initializing CUDA for gloo."""
+        if not dist.is_gloo_available():
+            self.skipTest("Gloo is unavailable in this PyTorch build.")
+
+        with tempfile.NamedTemporaryFile(delete=False) as init_handle:
+            init_file = init_handle.name
+
+        # FileStore expects to create the rendezvous file itself.
+        os.unlink(init_file)
+        original_interface = os.environ.get("GLOO_SOCKET_IFNAME")
+        if sys.platform == "darwin":
+            os.environ["GLOO_SOCKET_IFNAME"] = "lo0"
+
+        context = multiprocessing.get_context("spawn")
+        results = context.Queue()
+        processes = [context.Process(target=_all_gather_worker, args=(rank, init_file, results)) for rank in range(2)]
+        try:
+            for process in processes:
+                process.start()
+            for process in processes:
+                process.join(timeout=30)
+                self.assertFalse(process.is_alive(), "gloo worker did not exit")
+                self.assertEqual(process.exitcode, 0)
+
+            expected = [{"rank": 0, "payload": "x"}, {"rank": 1, "payload": "xx"}]
+            self.assertEqual([results.get(timeout=5) for _ in processes], [expected, expected])
+        finally:
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+                process.join()
+            results.close()
+            if original_interface is None:
+                os.environ.pop("GLOO_SOCKET_IFNAME", None)
+            else:
+                os.environ["GLOO_SOCKET_IFNAME"] = original_interface
+            if os.path.exists(init_file):
+                os.unlink(init_file)

--- a/tests/test_pytorch_coco_eval.py
+++ b/tests/test_pytorch_coco_eval.py
@@ -2,6 +2,7 @@
 
 import multiprocessing
 import os
+from pathlib import Path
 import sys
 import tempfile
 import unittest
@@ -16,7 +17,7 @@ from faster_coco_eval.utils.pytorch.coco_eval import all_gather
 
 def _all_gather_worker(rank, init_file, results):
     """Gather a rank-specific payload through a two-rank gloo group."""
-    dist.init_process_group("gloo", rank=rank, world_size=2, init_method=f"file://{init_file}")
+    dist.init_process_group("gloo", rank=rank, world_size=2, init_method=Path(init_file).absolute().as_uri())
     try:
         results.put(all_gather({"rank": rank, "payload": "x" * (rank + 1)}))
     finally:


### PR DESCRIPTION
This pull request improves the `all_gather` helper in `faster_coco_eval/utils/pytorch/coco_eval.py` to better support PyTorch distributed backends, especially Gloo, and adds regression tests to ensure correct behavior when gathering data across processes with different payload sizes.

**Distributed Backend Compatibility Improvements:**

* Updated `all_gather` to select the appropriate device (`cpu` for Gloo and other non-NCCL backends, `cuda` for NCCL) when creating tensors, ensuring compatibility and preventing runtime errors.
* Adjusted tensor creation and padding logic to consistently use the chosen device and properly handle different payload sizes, fixing bugs in gathering tensors of unequal size.

**Testing Enhancements:**

* Added a new regression test (`tests/test_pytorch_coco_eval.py`) that uses multiprocessing to verify that `all_gather` correctly collects picklable data with unequal payload sizes across two ranks using the Gloo backend, without requiring CUDA initialization.

---

part of #80