### PR TITLE
fix(utils): preserve matrices during normalization

### DIFF
--- a/faster_coco_eval/extra/draw.py
+++ b/faster_coco_eval/extra/draw.py
@@ -335,7 +335,8 @@ def display_matrix(
     Args:
         conf_matrix (np.ndarray): Confusion matrix (shape: [n_classes, n_classes + 2]).
         labels (list): List of class labels.
-        normalize (bool, optional): If True, normalize the confusion matrix to percentage. Default is False.
+        normalize (bool, optional): If True, normalize each row, including the appended fp and fn columns, to
+            percentages. Rows with a zero total remain zero. Default is False.
         return_fig (bool, optional): If True, return the figure object. Default is False.
 
     Returns:
@@ -346,8 +347,10 @@ def display_matrix(
     _labels = labels + ["fp", "fn"]
 
     if normalize:
-        conf_matrix /= conf_matrix.sum(axis=1).reshape(-1, 1)
-        conf_matrix *= 100
+        conf_matrix = conf_matrix.astype(float, copy=True)
+        row_totals = conf_matrix.sum(axis=1, keepdims=True)
+        row_totals[row_totals == 0] = 1
+        conf_matrix = conf_matrix / row_totals * 100
 
     hovertemplate = "Real: %{y}<br>Predict: %{x}<br>"
 

--- a/tests/test_display_matrix_normalization.py
+++ b/tests/test_display_matrix_normalization.py
@@ -15,10 +15,9 @@ class FakeHeatmap:
 class FakeFigure:
     """Provide the Plotly figure methods used by the display helper."""
 
-    def __init__(self, data, layout):
+    def __init__(self, data=None, layout=None, **kwargs):
         self.data = data
         self.layout = layout
-
     def update_traces(self, **kwargs):
         self.trace_updates = kwargs
 

--- a/tests/test_display_matrix_normalization.py
+++ b/tests/test_display_matrix_normalization.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from faster_coco_eval.extra import draw
+
+
+class FakeHeatmap:
+    """Capture heatmap parameters without requiring Plotly."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class FakeFigure:
+    """Provide the Plotly figure methods used by the display helper."""
+
+    def __init__(self, data, layout):
+        self.data = data
+        self.layout = layout
+
+    def update_traces(self, **kwargs):
+        self.trace_updates = kwargs
+
+    def update_layout(self, **kwargs):
+        self.layout_updates = kwargs
+
+
+def test_display_matrix_normalization_preserves_input_and_handles_empty_rows(monkeypatch):
+    """Normalize a copy and map rows with no samples to zero percentages."""
+    fake_go = SimpleNamespace(Figure=FakeFigure, Heatmap=FakeHeatmap)
+    monkeypatch.setattr(draw, "go", fake_go)
+    monkeypatch.setattr(draw, "plotly_available", True)
+    matrix = np.array([[2.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]])
+    original_matrix = matrix.copy()
+
+    figure = draw.display_matrix(matrix, ["class1", "class2"], normalize=True, return_fig=True)
+
+    np.testing.assert_array_equal(matrix, original_matrix)
+    np.testing.assert_allclose(figure.data[0].z[0], [40.0, 20.0, 20.0, 20.0])
+    assert np.isfinite(figure.data[0].z).all()
+    np.testing.assert_array_equal(figure.data[0].z[1], [0.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION
This pull request improves the normalization logic in the `display_matrix` function and adds a new test to ensure correct behavior. The main focus is on making normalization more robust, especially for rows with zero totals, and ensuring that the input matrix is not modified in-place.

**Improvements to normalization logic:**

* Updated the `display_matrix` function to normalize each row (including "fp" and "fn" columns) to percentages, ensuring that rows with zero totals remain zero. The normalization now operates on a float copy of the input matrix to avoid in-place modification. [[1]](diffhunk://#diff-3d0f5fa4586f2e8c6e2173fc587d57528f123f95dceab9e622c4b146734ad181L338-R339) [[2]](diffhunk://#diff-3d0f5fa4586f2e8c6e2173fc587d57528f123f95dceab9e622c4b146734ad181L349-R353)

**Testing enhancements:**

* Added a new test `test_display_matrix_normalization_preserves_input_and_handles_empty_rows` in `tests/test_display_matrix_normalization.py` to verify that normalization does not alter the original input matrix and that rows with all zeros are handled correctly.

---

part of #80