### PR TITLE
test(tests): stabilize comparator and distributed checks

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 numpy
-pycocotools
+pycocotools ; python_version < "3.13"
 pytest
 pytest-cov
 parameterized

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 numpy
-pycocotools ; python_version < "3.13"
+pycocotools
 pytest
 pytest-cov
 parameterized

--- a/tests/test_world_evalutor.py
+++ b/tests/test_world_evalutor.py
@@ -102,7 +102,7 @@ class TestWorldCoco(unittest.TestCase):
 
         world_size = 1
         # File rendezvous avoids sharing a TCP port with parallel test workers.
-        dist.init_process_group("gloo", rank=0, world_size=world_size, init_method=f"file://{self._rendezvous_path}")
+        dist.init_process_group("gloo", rank=0, world_size=world_size, init_method=f"file:///{self._rendezvous_path.lstrip('/')}" )
         self._owns_process_group = True
 
         for image_id, data in predictions.items():

--- a/tests/test_world_evalutor.py
+++ b/tests/test_world_evalutor.py
@@ -1,7 +1,9 @@
 import copy
 import os
+import tempfile
 import unittest
 from collections import defaultdict
+from unittest import mock
 
 from faster_coco_eval import COCO
 
@@ -20,8 +22,13 @@ class TestWorldCoco(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
+        """Prepare evaluation fixtures and an isolated Gloo rendezvous path."""
         self.gt_lvis_file = os.path.join("lvis_dataset", "lvis_val_100.json")
         self.dt_lvis_file = os.path.join("lvis_dataset", "lvis_results_100.json")
+        self._rendezvous_dir = tempfile.TemporaryDirectory()
+        self._rendezvous_path = os.path.join(self._rendezvous_dir.name, "gloo-rendezvous")
+        # Only a process group initialized by this test may be destroyed here.
+        self._owns_process_group = False
 
         if not os.path.exists(self.gt_lvis_file):
             self.gt_lvis_file = os.path.join(os.path.dirname(__file__), self.gt_lvis_file)
@@ -47,7 +54,33 @@ class TestWorldCoco(unittest.TestCase):
             "APf": 0.3875839974389359,
         }
 
+    def tearDown(self):
+        """Release distributed resources and the isolated rendezvous directory."""
+        try:
+            if self._owns_process_group and dist.is_initialized():
+                dist.destroy_process_group()
+        finally:
+            self._rendezvous_dir.cleanup()
+
+    def test_tear_down_destroys_initialized_process_group(self):
+        """Destroy the default process group after a distributed test."""
+        self._owns_process_group = True
+        with mock.patch.object(dist, "destroy_process_group") as destroy_process_group:
+            with mock.patch.object(dist, "is_initialized", return_value=True):
+                self.tearDown()
+
+        destroy_process_group.assert_called_once_with()
+
+    def test_tear_down_preserves_unowned_process_group(self):
+        """Avoid destroying a process group created outside this test case."""
+        with mock.patch.object(dist, "destroy_process_group") as destroy_process_group:
+            with mock.patch.object(dist, "is_initialized", return_value=True):
+                self.tearDown()
+
+        destroy_process_group.assert_not_called()
+
     def test_world_lvis(self):
+        """Evaluate LVIS predictions through an isolated single-process group."""
         coco_gt = COCO(self.gt_lvis_file)
         coco_eval_rank = FasterCocoEvaluator(coco_gt, iou_types=["bbox"], lvis_style=True)
         coco_eval_rank.coco_eval["bbox"].params.maxDets = [300]
@@ -68,7 +101,9 @@ class TestWorldCoco(unittest.TestCase):
             }
 
         world_size = 1
-        dist.init_process_group("gloo", rank=0, world_size=world_size, init_method="tcp://127.0.0.1:1234")
+        # File rendezvous avoids sharing a TCP port with parallel test workers.
+        dist.init_process_group("gloo", rank=0, world_size=world_size, init_method=f"file://{self._rendezvous_path}")
+        self._owns_process_group = True
 
         for image_id, data in predictions.items():
             coco_eval_rank.update({image_id: data})


### PR DESCRIPTION
This pull request improves the test isolation and resource management in the distributed evaluation tests. The main changes include introducing a temporary directory for rendezvous files, ensuring proper teardown of distributed process groups, and adding tests to verify correct teardown behavior.

**Test isolation and resource management:**

* [`tests/test_world_evalutor.py`](diffhunk://#diff-ba56b5d50a2f85bf44e691cb0c6fbd8139dd9d15a9e4ce99f628660ced0e371dR3-R6): Added use of `tempfile.TemporaryDirectory` to create an isolated rendezvous path for distributed tests, preventing conflicts between parallel test workers. [[1]](diffhunk://#diff-ba56b5d50a2f85bf44e691cb0c6fbd8139dd9d15a9e4ce99f628660ced0e371dR3-R6) [[2]](diffhunk://#diff-ba56b5d50a2f85bf44e691cb0c6fbd8139dd9d15a9e4ce99f628660ced0e371dR25-R31) [[3]](diffhunk://#diff-ba56b5d50a2f85bf44e691cb0c6fbd8139dd9d15a9e4ce99f628660ced0e371dL71-R106)
* [`tests/test_world_evalutor.py`](diffhunk://#diff-ba56b5d50a2f85bf44e691cb0c6fbd8139dd9d15a9e4ce99f628660ced0e371dR57-R83): Implemented a `tearDown` method to clean up the rendezvous directory and destroy the process group only if it was initialized by the test, ensuring proper resource release.
* [`tests/test_world_evalutor.py`](diffhunk://#diff-ba56b5d50a2f85bf44e691cb0c6fbd8139dd9d15a9e4ce99f628660ced0e371dR57-R83): Added tests to verify that the process group is only destroyed if owned by the test, preventing interference with external process groups.

**Dependency update:**

* [`requirements/tests.txt`](diffhunk://#diff-057d22d43e9cc37161e77506b5248167e608901e004bf9a94676d4802e1f074cL2-R2): Removed the Python version constraint from `pycocotools` to always include it in the test requirements.

---

Part of #80