### PR TITLE
fix(api): harden native RLE and evaluator inputs

### DIFF
--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 
 // clang-format off
@@ -198,68 +199,11 @@ std::vector<ImageEvaluation> EvaluateImages(
         const int num_categories = useCats ? (const int)cat_ids.size() : 1;
 
         if (image_category_ious.size() != img_ids.size()) {
-                throw std::runtime_error(
-                    "image_category_ious must contain one entry per image.");
-        }
-
-        const auto count_instances = [&](const LightweightDataset& dataset,
-                                         std::size_t image_index,
-                                         std::size_t category_index) {
-                if (useCats) {
-                        return dataset
-                            .get_cpp_annotations(img_ids[image_index],
-                                                 cat_ids[category_index])
-                            .size();
-                }
-
-                std::size_t count = 0;
-                for (const double cat_id : cat_ids) {
-                        count += dataset
-                                     .get_cpp_annotations(img_ids[image_index],
-                                                          cat_id)
-                                     .size();
-                }
-                return count;
-        };
-
-        // Validate all Python-provided IoU rows before matching can index them.
-        for (std::size_t i = 0; i < img_ids.size(); ++i) {
-                if (image_category_ious[i].size() !=
-                    static_cast<std::size_t>(num_categories)) {
-                        throw std::runtime_error(
-                            "image_category_ious must contain one entry per "
-                            "evaluated category.");
-                }
-
-                for (std::size_t c = 0; c < image_category_ious[i].size();
-                     ++c) {
-                        const std::size_t ground_truth_count =
-                            count_instances(gt_dataset, i, c);
-                        const std::size_t detection_count =
-                            count_instances(dt_dataset, i, c);
-
-                        const std::size_t expected_detections =
-                            ground_truth_count == 0 || detection_count == 0
-                                ? 0
-                                : std::min(
-                                      detection_count,
-                                      static_cast<std::size_t>(max_detections));
-                        const auto& category_ious = image_category_ious[i][c];
-                        if (category_ious.size() != expected_detections) {
-                                throw std::runtime_error(
-                                    "image_category_ious detection dimension "
-                                    "does not match the dataset.");
-                        }
-                        for (const auto& detection_ious : category_ious) {
-                                if (detection_ious.size() !=
-                                    ground_truth_count) {
-                                        throw std::runtime_error(
-                                            "image_category_ious ground-truth "
-                                            "dimension does not match the "
-                                            "dataset.");
-                                }
-                        }
-                }
+                std::ostringstream error;
+                error << "image_category_ious must contain one entry per image; "
+                      << "expected " << img_ids.size() << ", got "
+                      << image_category_ious.size() << ".";
+                throw std::runtime_error(error.str());
         }
 
         std::vector<uint64_t> detection_sorted_indices;
@@ -272,6 +216,18 @@ std::vector<ImageEvaluation> EvaluateImages(
         // Results for each IOU threshold are packed into the same
         // ImageEvaluation object
         for (auto i = 0; i < num_images; ++i) {
+                if (image_category_ious[i].size() !=
+                    static_cast<std::size_t>(num_categories)) {
+                        std::ostringstream error;
+                        error << "image_category_ious[" << i << "] for image id "
+                              << img_ids[i]
+                              << " must contain one entry per evaluated "
+                                 "category; expected "
+                              << num_categories << ", got "
+                              << image_category_ious[i].size() << ".";
+                        throw std::runtime_error(error.str());
+                }
+
                 for (auto c = 0; c < num_categories; ++c) {
                         // Read annotations on-demand from datasets
                         double img_id = img_ids[i];
@@ -323,6 +279,58 @@ std::vector<ImageEvaluation> EvaluateImages(
                                 detection_sorted_indices.resize(max_detections);
                         }
 
+                        const auto& category_ious = image_category_ious[i][c];
+                        const std::size_t expected_ground_truth =
+                            ground_truth_instances.size();
+                        const std::size_t expected_detections =
+                            expected_ground_truth == 0 ||
+                                    detection_sorted_indices.empty()
+                                ? 0
+                                : detection_sorted_indices.size();
+
+                        if (category_ious.size() != expected_detections) {
+                                std::ostringstream error;
+                                error << "image_category_ious[" << i << "]["
+                                      << c << "] for image id " << img_id;
+                                if (useCats) {
+                                        error << " and category id "
+                                              << cat_ids[c];
+                                } else {
+                                        error << " with merged categories";
+                                }
+                                error
+                                    << " has an invalid detection dimension; "
+                                       "expected "
+                                    << expected_detections << ", got "
+                                    << category_ious.size() << ".";
+                                throw std::runtime_error(error.str());
+                        }
+
+                        for (std::size_t d = 0; d < category_ious.size(); ++d) {
+                                if (category_ious[d].size() !=
+                                    expected_ground_truth) {
+                                        std::ostringstream error;
+                                        error
+                                            << "image_category_ious[" << i
+                                            << "][" << c << "][" << d
+                                            << "] for image id " << img_id;
+                                        if (useCats) {
+                                                error << " and category id "
+                                                      << cat_ids[c];
+                                        } else {
+                                                error
+                                                    << " with merged "
+                                                       "categories";
+                                        }
+                                        error
+                                            << " has an invalid ground-truth "
+                                               "dimension; expected "
+                                            << expected_ground_truth << ", got "
+                                            << category_ious[d].size() << ".";
+                                        throw std::runtime_error(error.str());
+                                }
+                        }
+
                         for (size_t a = 0; a < area_ranges.size(); ++a) {
                                 SortInstancesByIgnore(
                                     area_ranges[a], ground_truth_instances,
@@ -333,10 +341,9 @@ std::vector<ImageEvaluation> EvaluateImages(
                                     detection_sorted_indices,
                                     ground_truth_instances,
                                     ground_truth_sorted_indices, ignores,
-                                    image_category_ious[i][c], iou_thresholds,
-                                    area_ranges[a],
+                                    category_ious, iou_thresholds, area_ranges[a],
                                     &results_all[c * num_area_ranges *
-                                                     num_images +
+                                                    num_images +
                                                  a * num_images + i]);
                         }
 

--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
+#include <stdexcept>
 
 // clang-format off
 #include "cocoeval.h"
@@ -195,6 +196,72 @@ std::vector<ImageEvaluation> EvaluateImages(
         const int num_area_ranges = (const int)area_ranges.size();
         const int num_images = (const int)img_ids.size();
         const int num_categories = useCats ? (const int)cat_ids.size() : 1;
+
+        if (image_category_ious.size() != img_ids.size()) {
+                throw std::runtime_error(
+                    "image_category_ious must contain one entry per image.");
+        }
+
+        const auto count_instances = [&](const LightweightDataset& dataset,
+                                         std::size_t image_index,
+                                         std::size_t category_index) {
+                if (useCats) {
+                        return dataset
+                            .get_cpp_annotations(img_ids[image_index],
+                                                 cat_ids[category_index])
+                            .size();
+                }
+
+                std::size_t count = 0;
+                for (const double cat_id : cat_ids) {
+                        count += dataset
+                                     .get_cpp_annotations(img_ids[image_index],
+                                                          cat_id)
+                                     .size();
+                }
+                return count;
+        };
+
+        // Validate all Python-provided IoU rows before matching can index them.
+        for (std::size_t i = 0; i < img_ids.size(); ++i) {
+                if (image_category_ious[i].size() !=
+                    static_cast<std::size_t>(num_categories)) {
+                        throw std::runtime_error(
+                            "image_category_ious must contain one entry per "
+                            "evaluated category.");
+                }
+
+                for (std::size_t c = 0; c < image_category_ious[i].size();
+                     ++c) {
+                        const std::size_t ground_truth_count =
+                            count_instances(gt_dataset, i, c);
+                        const std::size_t detection_count =
+                            count_instances(dt_dataset, i, c);
+
+                        const std::size_t expected_detections =
+                            ground_truth_count == 0 || detection_count == 0
+                                ? 0
+                                : std::min(
+                                      detection_count,
+                                      static_cast<std::size_t>(max_detections));
+                        const auto& category_ious = image_category_ious[i][c];
+                        if (category_ious.size() != expected_detections) {
+                                throw std::runtime_error(
+                                    "image_category_ious detection dimension "
+                                    "does not match the dataset.");
+                        }
+                        for (const auto& detection_ious : category_ious) {
+                                if (detection_ious.size() !=
+                                    ground_truth_count) {
+                                        throw std::runtime_error(
+                                            "image_category_ious ground-truth "
+                                            "dimension does not match the "
+                                            "dataset.");
+                                }
+                        }
+                }
+        }
+
         std::vector<uint64_t> detection_sorted_indices;
         std::vector<uint64_t> ground_truth_sorted_indices;
         std::vector<bool> ignores;

--- a/csrc/mask_api/src/mask.h
+++ b/csrc/mask_api/src/mask.h
@@ -48,7 +48,7 @@ class RLE {
         }
 
         RLE(uint64_t h, uint64_t w, std::vector<uint64_t> cnts)
-            : h{h}, w{w}, m{1}, cnts{std::move(cnts)} {}
+            : RLE(h, w, cnts.size(), std::move(cnts)) {}
 
         uint64_t h;
         uint64_t w;

--- a/csrc/mask_api/src/mask.h
+++ b/csrc/mask_api/src/mask.h
@@ -22,12 +22,9 @@ namespace mask_api {
 namespace Mask {
 
 class RLE {
-       public:
-        RLE() : h{0}, w{0}, m{0} {}
-
-        RLE(uint64_t h, uint64_t w, uint64_t m, std::vector<uint64_t> cnts)
-            : h{h}, w{w}, m{m}, cnts{std::move(cnts)} {
-                if (m != this->cnts.size()) {
+       private:
+        void validate() const {
+                if (m != cnts.size()) {
                         throw std::range_error(
                             "RLE run count does not match cnts.size().");
                 }
@@ -38,7 +35,7 @@ class RLE {
 
                 const uint64_t max_pixels = h * w;
                 uint64_t total = 0;
-                for (const uint64_t count : this->cnts) {
+                for (const uint64_t count : cnts) {
                         if (count > max_pixels - total) {
                                 throw std::range_error(
                                     "RLE counts exceed the mask dimensions.");
@@ -47,8 +44,19 @@ class RLE {
                 }
         }
 
+       public:
+        RLE() : h{0}, w{0}, m{0} {}
+
+        RLE(uint64_t h, uint64_t w, uint64_t m, std::vector<uint64_t> cnts)
+            : h{h}, w{w}, m{m}, cnts{std::move(cnts)} {
+                validate();
+        }
+
         RLE(uint64_t h, uint64_t w, std::vector<uint64_t> cnts)
-            : RLE(h, w, cnts.size(), std::move(cnts)) {}
+            : h{h}, w{w}, m{0}, cnts{std::move(cnts)} {
+                m = this->cnts.size();
+                validate();
+        }
 
         uint64_t h;
         uint64_t w;

--- a/csrc/mask_api/src/mask.h
+++ b/csrc/mask_api/src/mask.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace py = pybind11;
@@ -25,7 +26,7 @@ class RLE {
         RLE() : h{0}, w{0}, m{0} {}
 
         RLE(uint64_t h, uint64_t w, uint64_t m, std::vector<uint64_t> cnts)
-            : h{h}, w{w}, m{m}, cnts{cnts} {
+            : h{h}, w{w}, m{m}, cnts{std::move(cnts)} {
                 if (m != this->cnts.size()) {
                         throw std::range_error(
                             "RLE run count does not match cnts.size().");
@@ -47,7 +48,7 @@ class RLE {
         }
 
         RLE(uint64_t h, uint64_t w, std::vector<uint64_t> cnts)
-            : h{h}, w{w}, m{1}, cnts{cnts} {}
+            : h{h}, w{w}, m{1}, cnts{std::move(cnts)} {}
 
         uint64_t h;
         uint64_t w;

--- a/csrc/mask_api/src/mask.h
+++ b/csrc/mask_api/src/mask.h
@@ -8,6 +8,8 @@
 #include <pybind11/stl_bind.h>
 
 #include <cmath>
+#include <limits>
+#include <stdexcept>
 #include <vector>
 
 namespace py = pybind11;
@@ -23,7 +25,26 @@ class RLE {
         RLE() : h{0}, w{0}, m{0} {}
 
         RLE(uint64_t h, uint64_t w, uint64_t m, std::vector<uint64_t> cnts)
-            : h{h}, w{w}, m{m}, cnts{cnts} {}
+            : h{h}, w{w}, m{m}, cnts{cnts} {
+                if (m != this->cnts.size()) {
+                        throw std::range_error(
+                            "RLE run count does not match cnts.size().");
+                }
+                if (w != 0 && h > std::numeric_limits<uint64_t>::max() / w) {
+                        throw std::range_error(
+                            "RLE dimensions overflow the pixel count.");
+                }
+
+                const uint64_t max_pixels = h * w;
+                uint64_t total = 0;
+                for (const uint64_t count : this->cnts) {
+                        if (count > max_pixels - total) {
+                                throw std::range_error(
+                                    "RLE counts exceed the mask dimensions.");
+                        }
+                        total += count;
+                }
+        }
 
         RLE(uint64_t h, uint64_t w, std::vector<uint64_t> cnts)
             : h{h}, w{w}, m{1}, cnts{cnts} {}

--- a/csrc/mask_api/src/rle.cpp
+++ b/csrc/mask_api/src/rle.cpp
@@ -258,19 +258,19 @@ RLE RLE::frPoly(const std::vector<double>& xy, uint64_t h, uint64_t w) {
         }
 
         // Compute RLE encoding given y-boundary points
-        std::vector<uint32_t> a;
+        std::vector<uint64_t> a;
         a.reserve(x.size() + 1);  // OPTIMIZATION: Pre-allocate memory
 
         for (std::size_t j = 0; j < x.size(); ++j)
-                a.emplace_back(
-                    static_cast<uint32_t>(x[j] * static_cast<int>(h) + y[j]));
-        a.emplace_back(static_cast<uint32_t>(h * w));
+                a.emplace_back(static_cast<uint64_t>(x[j]) * h +
+                               static_cast<uint64_t>(y[j]));
+        a.emplace_back(h * w);
 
         std::stable_sort(a.begin(), a.end());
 
-        uint32_t p = 0;
+        uint64_t p = 0;
         for (std::size_t j = 0; j < a.size(); ++j) {
-                uint32_t t = a[j];
+                uint64_t t = a[j];
                 a[j] -= p;
                 p = t;
         }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -248,6 +248,81 @@ class TestBaseCoco(unittest.TestCase):
         # Verify C++ annotation object exists and is correct type
         self.assertIsInstance(cpp_ann, _C.InstanceAnnotation)
 
+    @parameterized.expand([
+        ("missing_iou_rows", [[[]]]),
+        ("missing_iou_columns", [[[[]]]]),
+    ])
+    def test_evaluate_images_rejects_iou_shape_mismatch(self, _, ious):
+        """Reject IoU rows that do not match the dataset instance counts."""
+        gt_dataset = _C.Dataset()
+        dt_dataset = _C.Dataset()
+        gt_dataset.append(1, 1, {"id": 1, "area": 1.0, "ignore": False, "is_crowd": False})
+        dt_dataset.append(1, 1, {"id": 2, "score": 1.0, "area": 1.0, "ignore": False, "is_crowd": False})
+
+        with self.assertRaisesRegex(RuntimeError, "image_category_ious"):
+            _C.COCOevalEvaluateImages(
+                [[0.0, float("inf")]],
+                100,
+                [0.5],
+                ious,
+                gt_dataset,
+                dt_dataset,
+                [1],
+                [1],
+                True,
+            )
+
+    def test_evaluate_images_accepts_empty_ground_truth_iou_shape(self):
+        """Accept the empty IoU result used when an image has no ground
+        truth."""
+        gt_dataset = _C.Dataset()
+        dt_dataset = _C.Dataset()
+        dt_dataset.append(1, 1, {"id": 2, "score": 1.0, "area": 1.0, "ignore": False, "is_crowd": False})
+
+        evaluations = _C.COCOevalEvaluateImages(
+            [[0.0, float("inf")]],
+            100,
+            [0.5],
+            [[[]]],
+            gt_dataset,
+            dt_dataset,
+            [1],
+            [1],
+            True,
+        )
+
+        self.assertEqual(len(evaluations), 1)
+
+    def test_evaluate_images_validates_merged_category_iou_shape(self):
+        """Validate IoU dimensions after categories are merged."""
+        gt_dataset = _C.Dataset()
+        dt_dataset = _C.Dataset()
+        for category_id, annotation_id in [(1, 1), (2, 2)]:
+            gt_dataset.append(
+                1,
+                category_id,
+                {"id": annotation_id, "area": 1.0, "ignore": False, "is_crowd": False},
+            )
+            dt_dataset.append(
+                1,
+                category_id,
+                {"id": annotation_id + 10, "score": 1.0, "area": 1.0, "ignore": False, "is_crowd": False},
+            )
+
+        evaluations = _C.COCOevalEvaluateImages(
+            [[0.0, float("inf")]],
+            100,
+            [0.5],
+            [[[[0.5, 0.5], [0.5, 0.5]]]],
+            gt_dataset,
+            dt_dataset,
+            [1],
+            [1, 2],
+            False,
+        )
+
+        self.assertEqual(len(evaluations), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -116,14 +116,12 @@ class TestMaskApi(unittest.TestCase):
         self.assertTrue(np.all([_mask.encode(_mask.decode([rle])) == [rle] for rle in self.rleObjs]))
 
     def test_decode_rejects_count_larger_than_each_mask(self):
-        """Reject a second RLE whose runs exceed its own mask dimensions."""
-        valid, oversized = _mask.frUncompressedRLE([
-            {"size": [2, 2], "counts": [0, 4]},
-            {"size": [2, 2], "counts": [0, 5]},
-        ])
-
+        """Reject oversized uncompressed RLE counts at construction time."""
         with self.assertRaises(ValueError):
-            _mask.decode([valid, oversized])
+            _mask.frUncompressedRLE([
+                {"size": [2, 2], "counts": [0, 4]},
+                {"size": [2, 2], "counts": [0, 5]},
+            ])
 
     def test_decode_rejects_count_smaller_than_mask(self):
         """Reject a second RLE whose runs sum to fewer pixels than h*w."""
@@ -134,6 +132,31 @@ class TestMaskApi(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _mask.decode([valid, undersized])
+
+    def test_rejects_oversized_rle_before_mask_operations(self):
+        """Reject malformed RLE counts at every dense-mask entry point."""
+        oversized = {"size": [2, 2], "counts": b"05"}
+
+        with self.assertRaises(ValueError):
+            _mask.decode([oversized])
+        with self.assertRaises(ValueError):
+            _mask.merge([oversized, oversized])
+        with self.assertRaises(ValueError):
+            _mask.erode_3x3([oversized], 1)
+
+    def test_rle_rejects_count_length_mismatch(self):
+        """Reject an explicit run count length that disagrees with the data."""
+        with self.assertRaises(ValueError):
+            _mask.RLE(2, 2, 3, [0, 4])
+
+    def test_fr_poly_preserves_64_bit_pixel_offsets(self):
+        """Keep polygon RLE offsets above the uint32 range intact."""
+        height = 2**32 + 1
+        rle = _mask.frPoly([[0.0, 0.0, 0.0, 1.0]], height, 1)[0]
+
+        uncompressed = _mask.toUncompressedRLE([rle])[0]
+
+        self.assertEqual(sum(uncompressed["counts"]), height)
 
     def test_frBbox(self):
         self.assertEqual(self.bbox_rles, _mask.frBbox(self.bboxes, 20, 20))


### PR DESCRIPTION
This pull request strengthens input validation and error handling in both the COCO evaluation API and the mask API, ensuring that malformed or inconsistent input data is rejected early. It also extends the test suites to verify these behaviors and fixes a potential overflow issue in polygon RLE encoding.

**Input validation and error handling:**

* Added comprehensive validation in `EvaluateImages` to check the shape and dimensions of `image_category_ious`, raising descriptive errors when mismatches with dataset instance counts are found (`csrc/faster_eval_api/coco_eval/cocoeval.cpp`).
* Strengthened the `RLE` constructor to check for mismatches between the explicit run count and the data, pixel count overflows, and whether run lengths exceed the mask size, raising `std::range_error` on errors (`csrc/mask_api/src/mask.h`).
* Updated the polygon-to-RLE encoding to use 64-bit offsets, preventing overflow for very large masks (`csrc/mask_api/src/rle.cpp`).

**Test improvements:**

* Added new parameterized and explicit tests to ensure that the COCO evaluation API rejects malformed IoU input shapes, accepts empty ground-truth IoUs, and validates merged category shapes (`tests/test_dataset.py`).
* Improved mask API tests to verify that oversized RLEs are rejected at construction and before all dense-mask operations, and that mismatched run counts are caught. Added a test to ensure 64-bit polygon offsets are preserved (`tests/test_mask_api.py`) [[1]](diffhunk://#diff-b98c6dca768c3eabfb06e01183087a023cd88a44365426b01cd824f564757649L119-L127) [[2]](diffhunk://#diff-b98c6dca768c3eabfb06e01183087a023cd88a44365426b01cd824f564757649R136-R160).

**Dependency updates:**

* Included missing standard library headers for exceptions and limits to support new validations (`csrc/faster_eval_api/coco_eval/cocoeval.cpp`, `csrc/mask_api/src/mask.h`) [[1]](diffhunk://#diff-c64776a5ae1f84dcc4be1564f214818b8e0223bc9fce5d0d8834375b9ef672ccR6) [[2]](diffhunk://#diff-4c4013cdf6e953f14e78fb763cb43a803022eda452f31646a25c723ded5b9661R11-R12).

---

part of #80