### PR TITLE
fix(utils): resolve evaluation regressions

### DIFF
--- a/faster_coco_eval/extra/curves.py
+++ b/faster_coco_eval/extra/curves.py
@@ -30,17 +30,32 @@ class Curves(ExtraEval):
 
         if self.useCats:
             cat_ids = list(range(self.eval["precision"].shape[2]))
+            real_category_ids = list(self.cocoGt.cats)
         else:
             cat_ids = [0]
+            real_category_ids = []
 
-        for category_id in cat_ids:
+        for category_index in cat_ids:
+            category_id = real_category_ids[category_index] if self.useCats else category_index
             _label = f"[{label}={category_id}] "
             if len(cat_ids) == 1:
                 _label = ""
 
-            precision_list = self.eval["precision"][:, :, category_id, :, :].ravel()
-            recall_list = self.recThrs
-            scores = self.eval["scores"][:, :, category_id, :, :].ravel()
+            precision_list = self.eval["precision"][:, :, category_index, :, :].ravel()
+            recall_list = np.asarray(self.recThrs).ravel()
+            scores = self.eval["scores"][:, :, category_index, :, :].ravel()
+            point_count = min(len(recall_list), len(precision_list), len(scores))
+            recall_list = recall_list[:point_count]
+            precision_list = precision_list[:point_count]
+            scores = scores[:point_count]
+            valid = precision_list > -1
+            if not np.any(valid):
+                logger.warning("Skipping category %s: precision contains no valid values", category_id)
+                continue
+
+            recall_list = recall_list[valid]
+            precision_list = precision_list[valid]
+            scores = scores[valid]
             auc = round(COCOeval_faster.calc_auc(recall_list, precision_list), 4)
 
             curve.append(

--- a/faster_coco_eval/extra/curves.py
+++ b/faster_coco_eval/extra/curves.py
@@ -30,7 +30,10 @@ class Curves(ExtraEval):
 
         if self.useCats:
             cat_ids = list(range(self.eval["precision"].shape[2]))
-            real_category_ids = list(self.cocoGt.cats)
+            if hasattr(self, "params") and self.params is not None and self.params.catIds:
+                real_category_ids = list(self.params.catIds)
+            else:
+                real_category_ids = sorted(self.cocoGt.cats.keys())
         else:
             cat_ids = [0]
             real_category_ids = []

--- a/faster_coco_eval/extra/display.py
+++ b/faster_coco_eval/extra/display.py
@@ -129,6 +129,8 @@ class PreviewResults(ExtraEval):
 
         cm = np.zeros((K, K + 2), dtype=np.float32)
         for a, p in zip(y_true, y_pred):
+            if a not in categories_enum_ids or p not in categories_enum_ids:
+                continue
             cm[categories_enum_ids[a]][categories_enum_ids[p]] += 1
 
         for enum_id, category_id in enumerate(categories_real_ids):

--- a/faster_coco_eval/extra/draw.py
+++ b/faster_coco_eval/extra/draw.py
@@ -93,7 +93,7 @@ def generate_ann_polygon(
 
         for poly in ann["segmentation"]:
             if len(poly) > 3:
-                closed = list(poly) + poly[:2]
+                closed = list(poly) + list(poly[:2])
                 points = np.array(closed).reshape(-1, 2)
                 all_x += points[:, 0].tolist() + [None]
                 all_y += points[:, 1].tolist() + [None]

--- a/faster_coco_eval/extra/draw.py
+++ b/faster_coco_eval/extra/draw.py
@@ -93,10 +93,10 @@ def generate_ann_polygon(
 
         for poly in ann["segmentation"]:
             if len(poly) > 3:
-                poly += poly[:2]
-                poly = np.array(poly).reshape(-1, 2)
-                all_x += poly[:, 0].tolist() + [None]
-                all_y += poly[:, 1].tolist() + [None]
+                closed = list(poly) + poly[:2]
+                points = np.array(closed).reshape(-1, 2)
+                all_x += points[:, 0].tolist() + [None]
+                all_y += points[:, 1].tolist() + [None]
     elif iouType == "keypoints":
         skeleton = category_id_to_skeleton.get(ann.get("category_id"))
         keypoints = ann.get("keypoints")
@@ -414,9 +414,17 @@ def plot_pre_rec(curves, return_fig: bool = False):
     fig = go.Figure()
 
     for _curve in curves:
-        recall_list = _curve["recall_list"]
-        precision_list = _curve["precision_list"]
-        scores = _curve["scores"]
+        recall_list = np.asarray(_curve["recall_list"])
+        precision_list = np.asarray(_curve["precision_list"])
+        scores = np.asarray(_curve["scores"])
+        point_count = min(len(recall_list), len(precision_list), len(scores))
+        recall_list = recall_list[:point_count]
+        precision_list = precision_list[:point_count]
+        scores = scores[:point_count]
+        valid = precision_list > -1
+        recall_list = recall_list[valid]
+        precision_list = precision_list[valid]
+        scores = scores[valid]
 
         if "name" in _curve and len(_curve["name"]) > 0:
             name = _curve["name"]
@@ -477,9 +485,17 @@ def plot_f1_confidence(curves, return_fig: bool = False):
     fig = go.Figure()
     eps = 1e-16
     for _curve in curves:
-        recall_list = _curve["recall_list"]
-        precision_list = _curve["precision_list"][: len(recall_list)]
-        scores = _curve["scores"]
+        recall_list = np.asarray(_curve["recall_list"])
+        precision_list = np.asarray(_curve["precision_list"])
+        scores = np.asarray(_curve["scores"])
+        point_count = min(len(recall_list), len(precision_list), len(scores))
+        recall_list = recall_list[:point_count]
+        precision_list = precision_list[:point_count]
+        scores = scores[:point_count]
+        valid = precision_list > -1
+        recall_list = recall_list[valid]
+        precision_list = precision_list[valid]
+        scores = scores[valid]
         f1_curve = 2 * precision_list * recall_list / (precision_list + recall_list + eps)
 
         if "name" in _curve and len(_curve["name"]) > 0:

--- a/faster_coco_eval/extra/extra.py
+++ b/faster_coco_eval/extra/extra.py
@@ -75,7 +75,9 @@ class ExtraEval:
             extra_calc=True,
             kpt_oks_sigmas=self.kpt_oks_sigmas,
         )
-        cocoEval.params.maxDets = [len(self.cocoGt.anns)]
+        if not self.cocoGt.anns:
+            logger.warning("Ground-truth annotations are empty; detections will be scored as false positives")
+        cocoEval.params.maxDets = [max(1000, len(self.cocoDt.anns))]
 
         self.recThrs = np.linspace(0, 1, self.recall_count + 1, endpoint=True)
         cocoEval.params.recThrs = self.recThrs
@@ -106,25 +108,17 @@ class ExtraEval:
         assert self.cocoDt is not None, "cocoDt is empty"
 
         if min_score > 0:
-            bad_keys = {}
-            bad_images_keys = []
+            bad_ann_ids = set()
 
-            for key, ann in self.cocoDt.anns.items():
+            for ann_id, ann in self.cocoDt.anns.items():
                 if ann["score"] < min_score:
-                    if bad_keys.get(ann["image_id"]) is None:
-                        bad_keys[ann["image_id"]] = {}
+                    bad_ann_ids.add(ann_id)
 
-                    bad_keys[ann["image_id"]][key] = True
-
-                    bad_images_keys.append(ann["image_id"])
-
-            for image_id in set(bad_images_keys):
-                self.cocoDt.imgToAnns[image_id] = [
-                    ann for ann in self.cocoDt.imgToAnns[image_id] if bad_keys.get(image_id, {}).get(ann["id"]) is None
+            if bad_ann_ids:
+                self.cocoDt.dataset["annotations"] = [
+                    ann for ann in self.cocoDt.dataset["annotations"] if ann["id"] not in bad_ann_ids
                 ]
-
-                for ann_id in bad_keys.get(image_id, {}).keys():
-                    del self.cocoDt.anns[ann_id]
+                self.cocoDt.createIndex()
 
     @property
     def fp_image_ann_map(self) -> Dict[int, Set[int]]:

--- a/faster_coco_eval/utils/pytorch/coco_dataset.py
+++ b/faster_coco_eval/utils/pytorch/coco_dataset.py
@@ -11,9 +11,6 @@ from typing import Callable, Optional, Union
 import torchvision
 
 import faster_coco_eval
-from faster_coco_eval import COCO
-
-faster_coco_eval.init_as_pycocotools()
 
 
 class FasterCocoDetection(torchvision.datasets.CocoDetection):
@@ -53,6 +50,6 @@ class FasterCocoDetection(torchvision.datasets.CocoDetection):
         Returns:
             None
         """
-        super().__init__(root, transforms, transform, target_transform)
-        self.coco = COCO(annFile)
+        faster_coco_eval.init_as_pycocotools()
+        super().__init__(root, annFile, transform, target_transform, transforms)
         self.ids = list(sorted(self.coco.imgs.keys()))

--- a/tests/test_extra_curves.py
+++ b/tests/test_extra_curves.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from faster_coco_eval.extra.curves import Curves
+
+
+def test_build_curve_uses_real_category_ids_and_masks_sentinel_values(caplog):
+    """Build curves with real ids and omit categories with only invalid precision."""
+    curves = Curves.__new__(Curves)
+    curves.cocoGt = SimpleNamespace(cats={1: {"name": "cat"}, 17: {"name": "dog"}})
+    curves.eval = {
+        "precision": np.array([[[[[1.0]], [[-1.0]]], [[[0.5]], [[-1.0]]], [[[0.25]], [[-1.0]]]]]),
+        "scores": np.array([[[[[0.9]], [[-1.0]]], [[[0.5]], [[-1.0]]], [[[0.1]], [[-1.0]]]]]),
+    }
+    curves.recThrs = np.array([0.0, 0.5, 1.0])
+    curves.useCats = True
+
+    with caplog.at_level("WARNING"):
+        result = curves.build_curve("category_id")
+
+    assert len(result) == 1
+    assert result[0]["category_id"] == 1
+    assert result[0]["label"] == "[category_id=1] "
+    np.testing.assert_array_equal(result[0]["recall_list"], [0.0, 0.5, 1.0])
+    np.testing.assert_array_equal(result[0]["precision_list"], [1.0, 0.5, 0.25])
+    np.testing.assert_array_equal(result[0]["scores"], [0.9, 0.5, 0.1])
+    assert "17" in caplog.text

--- a/tests/test_extra_draw.py
+++ b/tests/test_extra_draw.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from copy import deepcopy
 
 import numpy as np
 
@@ -58,12 +59,17 @@ class TestExtraDraw(unittest.TestCase):
     def test_generate_ann_polygon_segm(self):
         ann = {"bbox": [10, 10, 20, 20], "segmentation": [[10, 10, 30, 10, 30, 30, 10, 30]], "category_id": 1}
         color = (255, 0, 0, 0.5)
+        original_segmentation = deepcopy(ann["segmentation"])
         # convert_ann_rle_to_poly just returns ann for this case (see import)
         result = generate_ann_polygon(ann, color, iouType="segm")
+        repeated_result = generate_ann_polygon(ann, color, iouType="segm")
         self.assertIsInstance(result, go.Scatter)
         # Check that coordinates start with 10, 10
         self.assertTrue(result.x[0] == 10)
         self.assertTrue(result.y[0] == 10)
+        self.assertEqual(ann["segmentation"], original_segmentation)
+        self.assertEqual(list(result.x), list(repeated_result.x))
+        self.assertEqual(list(result.y), list(repeated_result.y))
         self.assertEqual(result.line["color"], "rgb(255, 0, 0)")
         self.assertEqual(result.fillcolor, "rgba(255, 0, 0, 0.5)")
 
@@ -142,6 +148,25 @@ class TestExtraDraw(unittest.TestCase):
         self.assertEqual(fig.data[0].name, "curve1")
         # Check that F1 is calculated correctly (for first point F1==0, for second 2*0.8*0.5/(0.8+0.5)=0.615...)
         self.assertAlmostEqual(fig.data[0].y[1], 2 * 0.8 * 0.5 / (0.8 + 0.5), places=4)
+
+    def test_plot_curves_ignore_invalid_precision(self):
+        curves = [
+            {
+                "recall_list": np.array([0.0, 0.5, 1.0]),
+                "precision_list": np.array([1.0, -1.0, 0.5]),
+                "scores": np.array([0.9, 0.4, 0.1]),
+                "label": "curve1",
+            }
+        ]
+
+        precision_recall = plot_pre_rec(curves, return_fig=True)
+        f1_confidence = plot_f1_confidence(curves, return_fig=True)
+
+        np.testing.assert_array_equal(precision_recall.data[0].x, [0.0, 1.0])
+        np.testing.assert_array_equal(precision_recall.data[0].y, [1.0, 0.5])
+        np.testing.assert_array_equal(precision_recall.data[0].text, [0.9, 0.1])
+        np.testing.assert_allclose(f1_confidence.data[0].x, [0.9, 0.1])
+        np.testing.assert_allclose(f1_confidence.data[0].y, [0.0, 2 * 0.5 / 1.5])
 
     def test_plot_ced_metric(self):
         curves = [

--- a/tests/test_extra_regressions.py
+++ b/tests/test_extra_regressions.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from faster_coco_eval.extra import draw
+
+
+class FakeScatter:
+    """Capture scatter arguments without requiring Plotly."""
+
+    def __init__(self, **kwargs):
+        """Store scatter arguments as attributes."""
+        self.__dict__.update(kwargs)
+
+
+class FakeFigure:
+    """Capture plotted traces without requiring Plotly."""
+
+    def __init__(self):
+        """Initialize empty trace and axis collections."""
+        self.data = []
+        self.layout = SimpleNamespace(xaxis=SimpleNamespace(), yaxis=SimpleNamespace())
+
+    def add_trace(self, trace):
+        """Append one plotted trace."""
+        self.data.append(trace)
+
+    def update_layout(self, _layout):
+        """Accept layout updates for compatibility with Plotly."""
+        return None
+
+    def update_xaxes(self, **_kwargs):
+        """Accept x-axis updates for compatibility with Plotly."""
+        return None
+
+    def update_yaxes(self, **_kwargs):
+        """Accept y-axis updates for compatibility with Plotly."""
+        return None
+
+
+def test_generate_ann_polygon_does_not_mutate_segmentation(monkeypatch):
+    """Close polygon coordinates in a temporary list for repeatable rendering."""
+    monkeypatch.setattr(draw, "go", SimpleNamespace(Scatter=FakeScatter))
+    monkeypatch.setattr(draw, "plotly_available", True)
+    segmentation = [[10, 10, 30, 10, 30, 30, 10, 30]]
+    ann = {"segmentation": segmentation}
+
+    first = draw.generate_ann_polygon(ann, (255, 0, 0, 0.5), iouType="segm")
+    second = draw.generate_ann_polygon(ann, (255, 0, 0, 0.5), iouType="segm")
+
+    assert segmentation == [[10, 10, 30, 10, 30, 30, 10, 30]]
+    assert first.x == second.x
+    assert first.y == second.y
+
+
+def test_plot_curves_filter_invalid_precision(monkeypatch):
+    """Do not plot the -1 precision sentinel or compute negative F1 values."""
+    monkeypatch.setattr(draw, "go", SimpleNamespace(Figure=FakeFigure, Scatter=FakeScatter))
+    monkeypatch.setattr(draw, "plotly_available", True)
+    curves = [
+        {
+            "recall_list": np.array([0.0, 0.5, 1.0]),
+            "precision_list": np.array([1.0, -1.0, 0.5]),
+            "scores": np.array([0.9, 0.4, 0.1]),
+            "label": "curve1",
+        }
+    ]
+
+    precision_recall = draw.plot_pre_rec(curves, return_fig=True)
+    f1_confidence = draw.plot_f1_confidence(curves, return_fig=True)
+
+    np.testing.assert_array_equal(precision_recall.data[0].x, [0.0, 1.0])
+    np.testing.assert_array_equal(precision_recall.data[0].y, [1.0, 0.5])
+    np.testing.assert_array_equal(precision_recall.data[0].text, [0.9, 0.1])
+    np.testing.assert_allclose(f1_confidence.data[0].x, [0.9, 0.1])
+    np.testing.assert_allclose(f1_confidence.data[0].y, [0.0, 2 * 0.5 / 1.5])

--- a/tests/test_pytorch_coco_dataset.py
+++ b/tests/test_pytorch_coco_dataset.py
@@ -1,0 +1,55 @@
+import importlib
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+try:
+    import torchvision
+except ImportError:
+    raise unittest.SkipTest("Skipping PyTorch dataset tests because torchvision is unavailable.")
+
+import faster_coco_eval
+from faster_coco_eval.utils.pytorch import coco_dataset
+
+
+def test_import_does_not_patch_pycocotools():
+    """Importing the dataset module must not mutate process-wide modules."""
+    with patch.object(faster_coco_eval, "init_as_pycocotools") as init_as_pycocotools:
+        importlib.reload(coco_dataset)
+
+    init_as_pycocotools.assert_not_called()
+
+
+def test_constructor_patches_before_base_parse_and_reuses_base_coco():
+    """Initialize the compatibility module before torchvision parses annotations."""
+
+    def fake_base_init(dataset, *args, **kwargs):
+        """Provide the COCO object that torchvision normally creates."""
+        dataset.coco = SimpleNamespace(imgs={2: {}})
+
+    with (
+        patch.object(faster_coco_eval, "init_as_pycocotools") as init_as_pycocotools,
+        patch.object(
+            torchvision.datasets.CocoDetection, "__init__", autospec=True, side_effect=fake_base_init
+        ) as base_init,
+        patch.object(coco_dataset, "COCO", create=True) as explicit_coco,
+    ):
+        dataset = coco_dataset.FasterCocoDetection(
+            "root",
+            "annotations.json",
+            transform="transform",
+            target_transform="target",
+            transforms="transforms",
+        )
+
+    init_as_pycocotools.assert_called_once_with()
+    base_init.assert_called_once_with(
+        dataset,
+        "root",
+        "annotations.json",
+        "transform",
+        "target",
+        "transforms",
+    )
+    explicit_coco.assert_not_called()
+    assert dataset.ids == [2]

--- a/tests/test_simple_extra.py
+++ b/tests/test_simple_extra.py
@@ -1,9 +1,11 @@
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
 
 from faster_coco_eval import COCO, COCOeval_faster
+from faster_coco_eval.extra.display import PreviewResults
 from faster_coco_eval.extra.extra import ExtraEval
 
 
@@ -43,6 +45,16 @@ def test_extra_eval_non_keypoints():
 
         assert extra_eval.useCats is True
         assert extra_eval.kpt_oks_sigmas is None
+
+
+def test_confusion_matrix_ignores_detection_category_outside_ground_truth():
+    """Ignore unmatched category ids instead of indexing outside the matrix."""
+    preview = PreviewResults.__new__(PreviewResults)
+    preview.cocoGt = SimpleNamespace(cats={1: {"id": 1}})
+
+    result = preview._compute_confusion_matrix([1], [99])
+
+    np.testing.assert_array_equal(result, np.zeros((1, 3), dtype=np.float32))
 
 
 def test_evaluate_assertion():
@@ -86,6 +98,58 @@ def test_drop_cocodt_by_score_zero():
         # Should not modify anything when min_score is 0
         extra_eval.drop_cocodt_by_score(0.0)
         assert len(mock_dt.anns) == 1
+
+
+def test_evaluate_uses_detection_count_for_max_dets():
+    """Score all detections even when the ground truth has fewer annotations."""
+    mock_gt = Mock()
+    mock_gt.anns = {1: {"id": 1}}
+    mock_dt = Mock()
+    mock_dt.anns = {index: {"id": index} for index in range(1, 1202)}
+
+    with patch.object(ExtraEval, "evaluate"):
+        extra_eval = ExtraEval(cocoGt=mock_gt, cocoDt=None)
+    extra_eval.cocoDt = mock_dt
+
+    fake_eval = Mock()
+    fake_eval.params = SimpleNamespace()
+    fake_eval.eval = {}
+    with patch("faster_coco_eval.extra.extra.COCOeval_faster", return_value=fake_eval):
+        extra_eval.evaluate()
+
+    assert fake_eval.params.maxDets == [1201]
+
+
+def test_drop_cocodt_by_score_rebuilds_all_indexes():
+    """Remove low-score detections from the dataset and every derived index."""
+    ground_truth = COCO()
+    ground_truth.dataset = {
+        "images": [{"id": 1}],
+        "annotations": [],
+        "categories": [{"id": 1}],
+    }
+    ground_truth.createIndex()
+
+    detections = COCO()
+    detections.dataset = {
+        "images": [{"id": 1}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "score": 0.1},
+            {"id": 2, "image_id": 1, "category_id": 1, "score": 0.9},
+        ],
+        "categories": [{"id": 1}],
+    }
+    detections.createIndex()
+
+    with patch.object(ExtraEval, "evaluate"):
+        extra_eval = ExtraEval(cocoGt=ground_truth, cocoDt=detections)
+
+    extra_eval.drop_cocodt_by_score(0.5)
+
+    assert [ann["id"] for ann in extra_eval.cocoDt.dataset["annotations"]] == [2]
+    assert list(extra_eval.cocoDt.anns) == [2]
+    assert [ann["id"] for ann in extra_eval.cocoDt.imgToAnns[1]] == [2]
+    assert extra_eval.cocoDt.catToImgs[1] == [1]
 
 
 def test_fp_image_ann_map_empty():


### PR DESCRIPTION
This pull request improves the robustness, correctness, and test coverage of the COCO evaluation and visualization utilities. The main changes include better handling of invalid or missing data in curve generation and plotting, ensuring that data structures are not mutated unexpectedly, and making the PyTorch dataset integration safer and more compatible. Comprehensive tests have been added to verify these behaviors.

**Robustness and correctness improvements:**

* The `build_curve` method now uses real category IDs, properly skips categories with only invalid precision values, and ensures recall, precision, and score arrays are aligned and filtered for valid entries. Warnings are logged when skipping invalid categories.
* The plotting functions (`plot_pre_rec` and `plot_f1_confidence`) now filter out invalid precision values (e.g., `-1` sentinel) to avoid plotting or calculating with them, ensuring only valid data is visualized. [[1]](diffhunk://#diff-3d0f5fa4586f2e8c6e2173fc587d57528f123f95dceab9e622c4b146734ad181L417-R427) [[2]](diffhunk://#diff-3d0f5fa4586f2e8c6e2173fc587d57528f123f95dceab9e622c4b146734ad181L480-R498)
* The confusion matrix computation now ignores predictions or ground truths with category IDs not present in the ground truth categories, preventing out-of-bounds errors. [[1]](diffhunk://#diff-189ef52326ed0d547615fbe6d70b66970f02bac75531891584716b77665e2608R132-R133) [[2]](diffhunk://#diff-87cd5e49ecfb8e4dc8da48cce372e33b37a878d073f44ef4bc9661bb8b6ecfa2R50-R59)

**Data integrity and mutation safety:**

* The `generate_ann_polygon` function now closes polygons using a temporary list instead of mutating the original segmentation, ensuring input data remains unchanged across calls. [[1]](diffhunk://#diff-3d0f5fa4586f2e8c6e2173fc587d57528f123f95dceab9e622c4b146734ad181L96-R99) [[2]](diffhunk://#diff-b2be80d9f89bc2077577e435cd32fda82b5adbf36fdd3421340668756d976eaeR62-R72) [[3]](diffhunk://#diff-777888a09c71ca9b4ea7e687baa7c16f692b40254787c24af91e30562e80b194R1-R76)

**PyTorch dataset integration:**

* The PyTorch COCO dataset wrapper no longer patches global modules at import time, only during construction, and correctly initializes the base class and COCO instance, improving compatibility and preventing side effects. [[1]](diffhunk://#diff-7a980ad3183de3bde96a0f430a85faaa72ccd2ddbeef9b4e5abd599b10a843a9L14-L16) [[2]](diffhunk://#diff-7a980ad3183de3bde96a0f430a85faaa72ccd2ddbeef9b4e5abd599b10a843a9L56-R54) [[3]](diffhunk://#diff-9b8b5613f81debc5b79e7dc3fc6fecb409e017df7a1f5ef77e0da30212003eccR1-R55)

**Evaluation logic improvements:**

* The evaluation logic now sets `maxDets` based on the number of detections (not ground truth), and warns if ground-truth annotations are empty, ensuring all detections are considered and users are informed of potential issues. [[1]](diffhunk://#diff-e115d0c11c4659e820e69eeab829c81e34bd159ab53171ec68a9446e60c87fedL78-R80) [[2]](diffhunk://#diff-87cd5e49ecfb8e4dc8da48cce372e33b37a878d073f44ef4bc9661bb8b6ecfa2R103-R154)
* The method for dropping detections by score is simplified and now rebuilds all relevant indexes after removal, ensuring dataset consistency. [[1]](diffhunk://#diff-e115d0c11c4659e820e69eeab829c81e34bd159ab53171ec68a9446e60c87fedL109-R121) [[2]](diffhunk://#diff-87cd5e49ecfb8e4dc8da48cce372e33b37a878d073f44ef4bc9661bb8b6ecfa2R103-R154)

**Test coverage:**

* New and updated tests verify that invalid precision values are filtered, polygons are not mutated, confusion matrices handle unknown categories, and PyTorch dataset integration is safe and correct. [[1]](diffhunk://#diff-c0d63de5a6a643d8979b49fcd6e06268407bad2a394b8c5938d007abf0ae1958R1-R28) [[2]](diffhunk://#diff-b2be80d9f89bc2077577e435cd32fda82b5adbf36fdd3421340668756d976eaeR152-R170) [[3]](diffhunk://#diff-777888a09c71ca9b4ea7e687baa7c16f692b40254787c24af91e30562e80b194R1-R76) [[4]](diffhunk://#diff-9b8b5613f81debc5b79e7dc3fc6fecb409e017df7a1f5ef77e0da30212003eccR1-R55) [[5]](diffhunk://#diff-87cd5e49ecfb8e4dc8da48cce372e33b37a878d073f44ef4bc9661bb8b6ecfa2R1-R8) [[6]](diffhunk://#diff-87cd5e49ecfb8e4dc8da48cce372e33b37a878d073f44ef4bc9661bb8b6ecfa2R50-R59) [[7]](diffhunk://#diff-87cd5e49ecfb8e4dc8da48cce372e33b37a878d073f44ef4bc9661bb8b6ecfa2R103-R154)

---

part of #80