### PR TITLE
test(tests): harden medium review coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,16 @@ lint.mccabe.max-complexity = 10
 # Use Google-style docstrings.
 lint.pydocstyle.convention = "google"
 exclude = ["examples"]
+
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+  "slow: extensive cross-backend comparison tests",
+]
+filterwarnings = [
+  "default::DeprecationWarning",
+  "default::PendingDeprecationWarning",
+  "default::RuntimeWarning",
+  "error::pytest.PytestUnraisableExceptionWarning",
+]

--- a/scripts/derive_lvis_golden.py
+++ b/scripts/derive_lvis_golden.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Derive LVIS regression metrics with the official LVIS evaluation API."""
+
+import argparse
+import json
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ANNOTATIONS = PROJECT_ROOT / "tests/lvis_dataset/lvis_val_100.json"
+DEFAULT_PREDICTIONS = PROJECT_ROOT / "tests/lvis_dataset/lvis_results_100.json"
+
+
+def derive_metrics(annotation_file: Path, prediction_file: Path) -> dict[str, float]:
+    """Run official LVIS bbox evaluation and return its scalar metrics."""
+    try:
+        from lvis.eval import LVISEval
+        from lvis.lvis import LVIS
+    except ImportError as exc:
+        raise RuntimeError("Install the official lvis-api package before deriving LVIS goldens.") from exc
+
+    lvis_gt = LVIS(str(annotation_file))
+    evaluator = LVISEval(lvis_gt, str(prediction_file), iou_type="bbox")
+    evaluator.run()
+    return {key: float(value) for key, value in evaluator.get_results().items()}
+
+
+def main() -> None:
+    """Parse LVIS fixture paths and print official metrics as JSON."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("annotations", nargs="?", type=Path, default=DEFAULT_ANNOTATIONS)
+    parser.add_argument("predictions", nargs="?", type=Path, default=DEFAULT_PREDICTIONS)
+    args = parser.parse_args()
+
+    print(json.dumps(derive_metrics(args.annotations, args.predictions), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared pytest fixtures for deterministic test execution."""
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def seed_numpy_per_test():
+    """Reset NumPy's legacy global generator before each test."""
+    np.random.seed(0)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -87,6 +87,8 @@ class TestBaseCoco(unittest.TestCase):
             COCOeval_faster(cocoGt, cocoDt, "iouType")
 
     def test_ignore_coco_eval(self):
+        """Keep the ignore-case regression metrics within numeric tolerance."""
+        # Regression pin, recorded 2026-07-22 against faster_coco_eval 1.7.2.
         stats_as_dict = {
             "AP_all": 0.7099009900990099,
             "AP_50": 1.0,
@@ -126,6 +128,9 @@ class TestBaseCoco(unittest.TestCase):
             self.assertAlmostEqual(cocoEval.stats_as_dict[key], stats_as_dict[key], places=10, msg=key)
 
     def test_coco_eval(self):
+        """Keep the standard evaluation regression metrics within numeric
+        tolerance."""
+        # Regression pin, recorded 2026-07-22 against faster_coco_eval 1.7.2.
         stats_as_dict = {
             "AP_all": 0.6947194719471946,
             "AP_50": 0.6947194719471946,
@@ -158,7 +163,8 @@ class TestBaseCoco(unittest.TestCase):
         cocoEval.summarize()
 
         self.assertEqual(cocoEval.matched, True)
-        self.assertAlmostEqual(cocoEval.stats_as_dict, stats_as_dict, places=10)
+        for key, expected_value in stats_as_dict.items():
+            self.assertAlmostEqual(cocoEval.stats_as_dict[key], expected_value, places=10, msg=key)
 
     def test_confusion_matrix(self):
         prepared_result = [

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -95,6 +95,9 @@ class TestBoundary(unittest.TestCase):
         self.assertTrue(np.array_equal(opencv_rle_mask, self.mini_mask_boundry))
 
     def test_boundary_eval(self):
+        """Keep the boundary-evaluation regression metrics within numeric
+        tolerance."""
+        # Regression pin, recorded 2026-07-22 against faster_coco_eval 1.7.2.
         stats_as_dict = {
             # the following values (except for mIoU and mAUC_50) have been
             # obtained by running the original boundary_iou_api on
@@ -123,7 +126,8 @@ class TestBoundary(unittest.TestCase):
         cocoEval.accumulate()
         cocoEval.summarize()
 
-        self.assertAlmostEqual(cocoEval.stats_as_dict, stats_as_dict, places=10)
+        for key, expected_value in stats_as_dict.items():
+            self.assertAlmostEqual(cocoEval.stats_as_dict[key], expected_value, places=10, msg=key)
 
 
 if __name__ == "__main__":

--- a/tests/test_crowdpose.py
+++ b/tests/test_crowdpose.py
@@ -24,6 +24,8 @@ class TestCrowdpose(unittest.TestCase):
             self.dt_file = os.path.join(os.path.dirname(__file__), self.dt_file)
 
     def test_crowdpose_eval(self):
+        """Keep the CrowdPose regression metrics within numeric tolerance."""
+        # Regression pin, recorded 2026-07-22 against faster_coco_eval 1.7.2.
         stats_as_dict = {
             "AP_all": 0.7877215935879303,
             "AP_50": 0.9881188118811886,
@@ -48,7 +50,8 @@ class TestCrowdpose(unittest.TestCase):
         cocoEval.accumulate()
         cocoEval.summarize()
 
-        self.assertAlmostEqual(cocoEval.stats_as_dict, stats_as_dict, places=10)
+        for key, expected_value in stats_as_dict.items():
+            self.assertAlmostEqual(cocoEval.stats_as_dict[key], expected_value, places=10, msg=key)
 
 
 if __name__ == "__main__":

--- a/tests/test_extensive_pycocotools_comparison.py
+++ b/tests/test_extensive_pycocotools_comparison.py
@@ -13,6 +13,7 @@ import unittest
 from unittest import TestCase
 
 import numpy as np
+import pytest
 from parameterized import parameterized
 
 try:
@@ -26,6 +27,7 @@ import faster_coco_eval.core.mask as mask_util
 from faster_coco_eval import COCO, COCOeval_faster
 
 
+@pytest.mark.slow
 class TestExtensivePycocotoolsComparison(TestCase):
     """Extensive test suite comparing faster_coco_eval with pycocotools.
 
@@ -50,6 +52,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
         annotations_per_image=10,
         include_segmentation=False,
         include_keypoints=False,
+        crowd_fraction=0.0,
     ):
         """Create a synthetic COCO dataset with configurable parameters.
 
@@ -59,11 +62,15 @@ class TestExtensivePycocotoolsComparison(TestCase):
             annotations_per_image: Average number of annotations per image
             include_segmentation: Whether to include segmentation masks
             include_keypoints: Whether to include keypoint annotations
+            crowd_fraction: Fraction of ground-truth annotations marked as crowds.
 
         Returns:
             Dictionary containing COCO-formatted annotations
         """
-        np.random.seed(42)  # For reproducibility
+        if not 0.0 <= crowd_fraction <= 1.0:
+            raise ValueError("crowd_fraction must be between 0 and 1")
+
+        rng = np.random.default_rng(42)
 
         images = []
         annotations = []
@@ -86,8 +93,8 @@ class TestExtensivePycocotoolsComparison(TestCase):
         ann_id = 0
         for img_id in range(num_images):
             # Image dimensions vary
-            img_width = np.random.randint(400, 800)
-            img_height = np.random.randint(400, 800)
+            img_width = int(rng.integers(400, 800))
+            img_height = int(rng.integers(400, 800))
 
             images.append({
                 "id": img_id,
@@ -97,27 +104,27 @@ class TestExtensivePycocotoolsComparison(TestCase):
             })
 
             # Variable number of annotations per image
-            num_anns = np.random.randint(max(1, annotations_per_image - 5), annotations_per_image + 5)
+            num_anns = int(rng.integers(max(1, annotations_per_image - 5), annotations_per_image + 5))
 
             for _ in range(num_anns):
                 # Random category
-                cat_id = np.random.randint(0, num_categories)
+                cat_id = int(rng.integers(0, num_categories))
 
                 # Random bbox with various sizes
                 # Create small, medium, and large objects (COCO size categories)
-                size_type = np.random.choice(["small", "medium", "large"])
+                size_type = rng.choice(["small", "medium", "large"])
                 if size_type == "small":
-                    w = np.random.randint(10, 32)
-                    h = np.random.randint(10, 32)
+                    w = int(rng.integers(10, 32))
+                    h = int(rng.integers(10, 32))
                 elif size_type == "medium":
-                    w = np.random.randint(32, 96)
-                    h = np.random.randint(32, 96)
+                    w = int(rng.integers(32, 96))
+                    h = int(rng.integers(32, 96))
                 else:
-                    w = np.random.randint(96, min(200, img_width // 2))
-                    h = np.random.randint(96, min(200, img_height // 2))
+                    w = int(rng.integers(96, min(200, img_width // 2)))
+                    h = int(rng.integers(96, min(200, img_height // 2)))
 
-                x = np.random.randint(0, max(1, img_width - w))
-                y = np.random.randint(0, max(1, img_height - h))
+                x = int(rng.integers(0, max(1, img_width - w)))
+                y = int(rng.integers(0, max(1, img_height - h)))
 
                 area = w * h
 
@@ -127,7 +134,7 @@ class TestExtensivePycocotoolsComparison(TestCase):
                     "category_id": cat_id,
                     "bbox": [float(x), float(y), float(w), float(h)],
                     "area": float(area),
-                    "iscrowd": 0,
+                    "iscrowd": int(crowd_fraction > 0 and rng.random() < crowd_fraction),
                 }
 
                 if include_segmentation:
@@ -146,10 +153,10 @@ class TestExtensivePycocotoolsComparison(TestCase):
                     num_visible = 0
                     for i in range(num_keypoints):
                         # Some keypoints are visible (v=2), some occluded (v=1), some not labeled (v=0)
-                        visibility = int(np.random.choice([0, 1, 2], p=[0.1, 0.2, 0.7]))
+                        visibility = int(rng.choice([0, 1, 2], p=[0.1, 0.2, 0.7]))
                         if visibility > 0:
-                            kp_x = x + np.random.randint(0, max(1, w))
-                            kp_y = y + np.random.randint(0, max(1, h))
+                            kp_x = x + rng.integers(0, max(1, w))
+                            kp_y = y + rng.integers(0, max(1, h))
                         else:
                             kp_x = kp_y = 0
                         keypoints.extend([float(kp_x), float(kp_y), visibility])
@@ -181,13 +188,13 @@ class TestExtensivePycocotoolsComparison(TestCase):
         Returns:
             List of prediction dictionaries
         """
-        np.random.seed(123)  # Different seed for predictions
+        rng = np.random.default_rng(123)
 
         predictions = []
 
         for ann in coco_gt["annotations"]:
             # Only detect a fraction of objects
-            if np.random.random() > detection_rate:
+            if rng.random() > detection_rate:
                 continue
 
             pred = {
@@ -196,16 +203,16 @@ class TestExtensivePycocotoolsComparison(TestCase):
             }
 
             # Add score with some variation
-            base_score = np.random.uniform(0.5, 0.99)
+            base_score = rng.uniform(0.5, 0.99)
             pred["score"] = float(base_score)
 
             if iou_type in ["bbox", "segm"]:
                 # Add some noise to bbox
                 x, y, w, h = ann["bbox"]
-                noise_factor = np.random.uniform(0.9, 1.1)
+                noise_factor = rng.uniform(0.9, 1.1)
                 pred["bbox"] = [
-                    float(x + np.random.uniform(-2, 2)),
-                    float(y + np.random.uniform(-2, 2)),
+                    float(x + rng.uniform(-2, 2)),
+                    float(y + rng.uniform(-2, 2)),
                     float(w * noise_factor),
                     float(h * noise_factor),
                 ]
@@ -221,8 +228,8 @@ class TestExtensivePycocotoolsComparison(TestCase):
                 for i in range(0, len(ann["keypoints"]), 3):
                     kp_x, kp_y, v = ann["keypoints"][i : i + 3]
                     if v > 0:
-                        kp_x += np.random.uniform(-3, 3)
-                        kp_y += np.random.uniform(-3, 3)
+                        kp_x += rng.uniform(-3, 3)
+                        kp_y += rng.uniform(-3, 3)
                     keypoints.extend([float(kp_x), float(kp_y), v])
                 pred["keypoints"] = keypoints
 
@@ -233,15 +240,15 @@ class TestExtensivePycocotoolsComparison(TestCase):
         for img in coco_gt["images"][:num_false_positives]:
             pred = {
                 "image_id": img["id"],
-                "category_id": np.random.randint(0, len(coco_gt["categories"])),
-                "score": float(np.random.uniform(0.3, 0.7)),
+                "category_id": int(rng.integers(0, len(coco_gt["categories"]))),
+                "score": float(rng.uniform(0.3, 0.7)),
             }
 
             if iou_type in ["bbox", "segm"]:
-                w = np.random.randint(20, 100)
-                h = np.random.randint(20, 100)
-                x = np.random.randint(0, max(1, img["width"] - w))
-                y = np.random.randint(0, max(1, img["height"] - h))
+                w = int(rng.integers(20, 100))
+                h = int(rng.integers(20, 100))
+                x = int(rng.integers(0, max(1, img["width"] - w)))
+                y = int(rng.integers(0, max(1, img["height"] - h)))
                 pred["bbox"] = [float(x), float(y), float(w), float(h)]
                 pred["area"] = float(w * h)
 
@@ -258,8 +265,8 @@ class TestExtensivePycocotoolsComparison(TestCase):
                 keypoints = []
                 for i in range(17):
                     keypoints.extend([
-                        float(np.random.randint(0, img["width"])),
-                        float(np.random.randint(0, img["height"])),
+                        float(rng.integers(0, img["width"])),
+                        float(rng.integers(0, img["height"])),
                         2,
                     ])
                 pred["keypoints"] = keypoints
@@ -421,6 +428,40 @@ class TestExtensivePycocotoolsComparison(TestCase):
             f"\nDataset: {name} ({num_images} images, {len(coco_data['annotations'])} annotations, "
             f"{len(predictions)} predictions)\n"
             f"faster_coco_eval stats: {fast_stats}\n"
+            f"pycocotools stats:      {orig_stats}\n"
+            f"Difference: {fast_stats - orig_stats}",
+        )
+
+    @parameterized.expand([("bbox", False), ("segm", True)])
+    def test_crowd_annotations_extensive(self, iou_type, include_segmentation):
+        """Compare bbox and RLE-segmentation evaluation with crowd ground
+        truths."""
+        if origCOCO is None:
+            raise unittest.SkipTest("pycocotools not available")
+
+        coco_data = self._create_coco_annotations(
+            num_images=10,
+            num_categories=5,
+            annotations_per_image=5,
+            include_segmentation=include_segmentation,
+            crowd_fraction=0.15,
+        )
+        crowd_annotations = [ann for ann in coco_data["annotations"] if ann["iscrowd"]]
+        self.assertGreater(len(crowd_annotations), 0)
+        self.assertLess(len(crowd_annotations), len(coco_data["annotations"]))
+        if include_segmentation:
+            self.assertTrue(all(isinstance(ann["segmentation"], dict) for ann in crowd_annotations))
+
+        gt_file = osp.join(self.tmp_dir.name, f"gt_crowd_{iou_type}.json")
+        with open(gt_file, "w") as f:
+            json.dump(coco_data, f)
+
+        predictions = self._create_predictions(coco_data, iou_type=iou_type)
+        fast_stats, orig_stats, are_equal = self._compare_evaluators(gt_file, predictions, iou_type)
+
+        self.assertTrue(
+            are_equal,
+            f"\nfaster_coco_eval stats: {fast_stats}\n"
             f"pycocotools stats:      {orig_stats}\n"
             f"Difference: {fast_stats - orig_stats}",
         )

--- a/tests/test_extra_draw.py
+++ b/tests/test_extra_draw.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -23,8 +24,9 @@ from faster_coco_eval.extra.draw import (
 class DummyCOCO:
     """Minimal COCO mock for tests."""
 
-    def __init__(self):
-        self.imgs = {1: {"file_name": "test.jpg", "width": 100, "height": 100}}
+    def __init__(self, image_path):
+        """Build a minimal COCO object pointing at the test image."""
+        self.imgs = {1: {"file_name": image_path, "width": 100, "height": 100}}
         self.imgToAnns = {1: [{"id": 1, "bbox": [10, 10, 20, 20], "category_id": 1}]}
         self.cats = {1: {"id": 1, "name": "class1", "skeleton": []}}
 
@@ -33,16 +35,17 @@ class TestExtraDraw(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
-        self.dummy_coco = DummyCOCO()
+        """Create an isolated image fixture for the draw tests."""
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.image_path = os.path.join(self._temp_dir.name, "test.jpg")
+        self.dummy_coco = DummyCOCO(self.image_path)
         # Create a fake jpg file for testing
         img = Image.new("RGB", (100, 100), color=(255, 255, 255))
-        img.save("test.jpg")
+        img.save(self.image_path)
 
     def tearDown(self):
-        try:
-            os.remove("test.jpg")
-        except Exception:
-            pass
+        """Remove the isolated image fixture."""
+        self._temp_dir.cleanup()
 
     def test_generate_ann_polygon_bbox(self):
         ann = {"bbox": [10, 10, 20, 20], "category_id": 1}

--- a/tests/test_keypoints.py
+++ b/tests/test_keypoints.py
@@ -40,6 +40,8 @@ class TestKeypointsMetric(TestCase):
 
     @parameterized.expand([(COCO, COCOeval_faster), (origCOCO, origCOCOeval)])
     def test_evaluate(self, coco_cls, cocoeval_cls):
+        """Compare keypoint evaluation after both evaluators summarize
+        results."""
         if coco_cls is None:
             raise unittest.SkipTest("Skipping pycocotools test.")
 
@@ -53,12 +55,20 @@ class TestKeypointsMetric(TestCase):
         cocoEval.evaluate()
         cocoEval.accumulate()
 
-        if cocoeval_cls is COCOeval_faster:
-            print(str(cocoEval))
-        else:
-            cocoEval.summarize()
+        cocoEval.summarize()
 
         self.assertListEqual(cocoEval.stats.tolist(), self.results)
+
+    def test_evaluate_repr(self):
+        """Smoke-test the faster evaluator string representation
+        independently."""
+        coco_gt = COCO(self.gt_file)
+        coco_dt = coco_gt.loadRes(self.dt_file)
+        coco_eval = COCOeval_faster(coco_gt, coco_dt, "keypoints")
+        coco_eval.evaluate()
+        coco_eval.accumulate()
+
+        self.assertIn("COCOeval_faster", str(coco_eval))
 
     def test_evaluate_bad_config(self):
         cocoGt = COCO(self.gt_file)

--- a/tests/test_lvis_metric.py
+++ b/tests/test_lvis_metric.py
@@ -32,6 +32,8 @@ class TestBaseLvis(unittest.TestCase):
 
         self.prepared_anns_numpy = np.array(self.prepared_anns_numpy)
 
+        # Regression pin, recorded 2026-07-22 against faster_coco_eval 1.7.2.
+        # Cross-check with the official LVIS API using scripts/derive_lvis_golden.py.
         self.stats_as_dict_result = {
             "AP_all": 0.3676645003471999,
             "AP_50": 0.626197183778713,

--- a/tests/test_torchmetrics.py
+++ b/tests/test_torchmetrics.py
@@ -254,7 +254,7 @@ class TestTorchmetricsLib(TestCase):
         self.assertIsInstance(result, dict)
         torch.testing.assert_close(result["map"], torch.tensor(-1.0))
         torch.testing.assert_close(result["mar_100"], torch.tensor(-1.0))
-        self.assertTrue(torch.equal(result["classes"], torch.tensor([4], dtype=torch.int32)))
+        self.assertTrue(torch.equal(result["classes"].reshape(-1), torch.tensor([4], dtype=torch.int32)))
 
     @parameterized.expand([
         (backend, class_metrics) for backend in _AVAILABLE_BACKENDS for class_metrics in (False, True)

--- a/tests/test_torchmetrics.py
+++ b/tests/test_torchmetrics.py
@@ -1,5 +1,6 @@
 import unittest
 from copy import deepcopy
+from importlib.util import find_spec
 from unittest import TestCase
 
 from parameterized import parameterized
@@ -12,6 +13,10 @@ try:
     from torchmetrics.detection.mean_ap import MeanAveragePrecision
 except ImportError:
     raise unittest.SkipTest("Skipping all tests for torchmetrics.")
+
+_AVAILABLE_BACKENDS = ["faster_coco_eval"]
+if find_spec("pycocotools") is not None:
+    _AVAILABLE_BACKENDS.append("pycocotools")
 
 # fmt: off
 _inputs = {
@@ -229,32 +234,38 @@ class TestTorchmetricsLib(TestCase):
         self.assertDictEqual(result, self.valid_result)
 
     def test_segm_iou_empty_gt_mask(self):
-        """Test empty ground truths."""
+        """Validate deterministic metrics when the ground-truth mask is
+        empty."""
+        torch.manual_seed(42)
         backend = "faster_coco_eval"
         metric = MeanAveragePrecision(iou_type="segm", backend=backend)
         metric.update(
             [
                 {
-                    "masks": torch.randint(0, 1, (1, 10, 10)).bool(),
+                    "masks": torch.randint(0, 2, (1, 10, 10)).bool(),
                     "scores": Tensor([0.5]),
                     "labels": IntTensor([4]),
                 }
             ],
             [{"masks": Tensor([]), "labels": IntTensor([])}],
         )
-        metric.compute()
+        result = metric.compute()
 
-    @parameterized.expand([False, True])
-    def test_average_argument(self, class_metrics):
+        self.assertIsInstance(result, dict)
+        torch.testing.assert_close(result["map"], torch.tensor(-1.0))
+        torch.testing.assert_close(result["mar_100"], torch.tensor(-1.0))
+        self.assertTrue(torch.equal(result["classes"], torch.tensor([4], dtype=torch.int32)))
+
+    @parameterized.expand([
+        (backend, class_metrics) for backend in _AVAILABLE_BACKENDS for class_metrics in (False, True)
+    ])
+    def test_average_argument(self, backend, class_metrics):
         """Test that average argument works.
 
         Calculating macro on inputs that only have one label should be
         the same as micro. Calculating class metrics should be the same
         regardless of average argument.
         """
-        backend = "pycocotools"
-        backend = "faster_coco_eval"
-
         if class_metrics:
             _preds = _inputs["preds"]
             _target = _inputs["target"]

--- a/tests/test_world_evalutor.py
+++ b/tests/test_world_evalutor.py
@@ -34,6 +34,8 @@ class TestWorldCoco(unittest.TestCase):
             self.gt_lvis_file = os.path.join(os.path.dirname(__file__), self.gt_lvis_file)
             self.dt_lvis_file = os.path.join(os.path.dirname(__file__), self.dt_lvis_file)
 
+        # Regression pin, recorded 2026-07-22 against faster_coco_eval 1.7.2.
+        # Cross-check with the official LVIS API using scripts/derive_lvis_golden.py.
         self.stats_as_dict_result = {
             "AP_all": 0.3676645003471999,
             "AP_50": 0.626197183778713,
@@ -55,7 +57,8 @@ class TestWorldCoco(unittest.TestCase):
         }
 
     def tearDown(self):
-        """Release distributed resources and the isolated rendezvous directory."""
+        """Release distributed resources and the isolated rendezvous
+        directory."""
         try:
             if self._owns_process_group and dist.is_initialized():
                 dist.destroy_process_group()
@@ -80,7 +83,8 @@ class TestWorldCoco(unittest.TestCase):
         destroy_process_group.assert_not_called()
 
     def test_world_lvis(self):
-        """Evaluate LVIS predictions through an isolated single-process group."""
+        """Evaluate LVIS predictions through an isolated single-process
+        group."""
         coco_gt = COCO(self.gt_lvis_file)
         coco_eval_rank = FasterCocoEvaluator(coco_gt, iou_types=["bbox"], lvis_style=True)
         coco_eval_rank.coco_eval["bbox"].params.maxDets = [300]
@@ -102,7 +106,9 @@ class TestWorldCoco(unittest.TestCase):
 
         world_size = 1
         # File rendezvous avoids sharing a TCP port with parallel test workers.
-        dist.init_process_group("gloo", rank=0, world_size=world_size, init_method=f"file:///{self._rendezvous_path.lstrip('/')}" )
+        dist.init_process_group(
+            "gloo", rank=0, world_size=world_size, init_method=f"file:///{self._rendezvous_path.lstrip('/')}"
+        )
         self._owns_process_group = True
 
         for image_id, data in predictions.items():


### PR DESCRIPTION
This pull request introduces several improvements to the test suite and supporting scripts, focusing on reproducibility, regression tracking, and enhanced coverage. Notably, it adds deterministic seeding for NumPy-based randomness, improves regression metric tracking, refines the synthetic dataset generation for better test coverage, and introduces a utility script for LVIS metric derivation.

**Test reproducibility and regression tracking:**

* Added a shared pytest fixture in `tests/conftest.py` to seed NumPy's random generator before each test, ensuring deterministic test execution.
* Updated regression tests in `tests/test_basic.py`, `tests/test_boundary.py`, and `tests/test_crowdpose.py` to check individual metric values with `assertAlmostEqual` and added docstrings and regression pin comments for clarity and traceability. [[1]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R90-R91) [[2]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R131-R133) [[3]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7L161-R167) [[4]](diffhunk://#diff-37023d59f070d588935ef3336c45a07c4f4015f195efcb787641afa55f6d5f82R98-R100) [[5]](diffhunk://#diff-37023d59f070d588935ef3336c45a07c4f4015f195efcb787641afa55f6d5f82L126-R130) [[6]](diffhunk://#diff-572717ef2c92da9efa98370e86dac2e48842a93ac5df08a2b7becf7c064522caR27-R28) [[7]](diffhunk://#diff-572717ef2c92da9efa98370e86dac2e48842a93ac5df08a2b7becf7c064522caL51-R54)

**Test infrastructure and configuration:**

* Added pytest configuration to `pyproject.toml`, specifying test paths, markers, and warning filters for improved test management.

**Synthetic dataset and test enhancements:**

* Refactored synthetic COCO dataset and prediction generation in `tests/test_extensive_pycocotools_comparison.py` to use NumPy's `default_rng` for randomness, added a `crowd_fraction` parameter for testing crowd annotations, and marked the extensive comparison test as `slow`. Also, added a new test for crowd annotation evaluation. [[1]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29R16) [[2]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29R30) [[3]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29R55) [[4]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29R65-R73) [[5]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L89-R97) [[6]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L100-R127) [[7]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L130-R137) [[8]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L149-R159) [[9]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L184-R197) [[10]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L199-R215) [[11]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L224-R232) [[12]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L236-R251) [[13]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29L261-R269) [[14]](diffhunk://#diff-c1dc2d0fb2a7e1d350e6969c721c302decb64ad19ee3d89b537271d15cdc0b29R435-R468)

**Utility scripts:**

* Added `scripts/derive_lvis_golden.py`, a script to compute official LVIS regression metrics using the LVIS evaluation API, aiding in golden metric derivation and reproducibility.

**Minor improvements:**

* Improved the minimal COCO mock in `tests/test_extra_draw.py` to accept a test image path, increasing flexibility for test image handling. [[1]](diffhunk://#diff-b2be80d9f89bc2077577e435cd32fda82b5adbf36fdd3421340668756d976eaeR2) [[2]](diffhunk://#diff-b2be80d9f89bc2077577e435cd32fda82b5adbf36fdd3421340668756d976eaeL26-R29)

---

part of #80