### PR TITLE
perf(api): release GIL during IoU compute [boost 2.59x]

### DIFF
--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -657,14 +657,21 @@ std::variant<py::array_t<double, py::array::f_style>, std::vector<double>> iou(
         }
 
         std::vector<double> iou_result;
-        if (std::holds_alternative<std::vector<double>>(_dt)) {
-                const auto& _dt_box = std::get<std::vector<double>>(_dt);
-                const auto& _gt_box = std::get<std::vector<double>>(_gt);
-                iou_result = bbIou(_dt_box, _gt_box, m, n, iscrowd);
-        } else {
-                const auto& _dt_rle = std::get<std::vector<RLE>>(_dt);
-                const auto& _gt_rle = std::get<std::vector<RLE>>(_gt);
-                iou_result = rleIou(_dt_rle, _gt_rle, m, n, iscrowd);
+        {
+                // The remaining work only reads C++ values; keep Python API
+                // conversion and the returned array construction GIL-safe.
+                py::gil_scoped_release release;
+                if (std::holds_alternative<std::vector<double>>(_dt)) {
+                        const auto& _dt_box =
+                            std::get<std::vector<double>>(_dt);
+                        const auto& _gt_box =
+                            std::get<std::vector<double>>(_gt);
+                        iou_result = bbIou(_dt_box, _gt_box, m, n, iscrowd);
+                } else {
+                        const auto& _dt_rle = std::get<std::vector<RLE>>(_dt);
+                        const auto& _gt_rle = std::get<std::vector<RLE>>(_gt);
+                        iou_result = rleIou(_dt_rle, _gt_rle, m, n, iscrowd);
+                }
         }
         return py::array(iou_result.size(), iou_result.data()).reshape({m, n});
 }

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import sys
+import threading
 import unittest
 
 import faster_coco_eval.mask_api_new_cpp as _mask
@@ -230,6 +232,47 @@ class TestMaskApi(unittest.TestCase):
 
         result_poly_iou = module.iou(self.poly_rles[:3], self.poly_rles[:3], [0, 0, 0]).round(4)
         self.assertEqual(poly_iou.tolist(), result_poly_iou.tolist())
+
+    def test_iou_releases_gil_during_cpp_compute(self):
+        """Allow another Python thread to run during native IoU computation."""
+        rows, columns = np.indices((256, 256))
+        checkerboard = np.asfortranarray(((rows + columns) % 2).astype(np.uint8)[..., None])
+        encoded = _mask.encode(checkerboard)[0]
+        rles = [encoded] * 24
+        started = threading.Event()
+        finished = threading.Event()
+        errors = []
+
+        def compute_iou():
+            started.set()
+            try:
+                _mask.iou(rles, rles, [0] * len(rles))
+            except Exception as ex:  # pragma: no cover - surfaced below
+                errors.append(ex)
+            finally:
+                finished.set()
+
+        original_switch_interval = sys.getswitchinterval()
+        worker = threading.Thread(target=compute_iou)
+        observed_start = False
+        overlapped = False
+        try:
+            # Prevent a Python bytecode switch between started.set() and iou().
+            # The main thread can resume before completion only if native iou()
+            # releases the GIL.
+            sys.setswitchinterval(1.0)
+            worker.start()
+            observed_start = started.wait(timeout=1.0)
+            overlapped = observed_start and not finished.is_set()
+            worker.join(timeout=5.0)
+        finally:
+            sys.setswitchinterval(original_switch_interval)
+
+        self.assertTrue(observed_start, "IoU worker did not start")
+        self.assertFalse(worker.is_alive(), "IoU worker did not finish")
+        if errors:
+            raise errors[0]
+        self.assertTrue(overlapped, "Python thread could not run while native IoU was active")
 
     def test_iou_size_mismatch_writes_sentinel_to_pair(self):
         """Return -1 in each pair's output cell when RLE sizes differ."""


### PR DESCRIPTION
Changes:
- Release the GIL only around pure C++ bbIou/rleIou computation; keep Python conversion, validation, and array construction protected.
- Add a behavioral regression test proving another Python thread runs while native IoU is active.

Impact:
- Four concurrent calls measured 2.59x for RLE and 1.96x for bbox; single-call RLE remained 1.00x.
- Public API and numerical outputs remain unchanged.

Verification:
- Isolated baseline and changed extensions built successfully; output digests matched.
- Regression test failed without P-1, passed with P-1, and passed 10/10 repeated working-tree runs.
- Non-distributed suite: 140 passed, 2 skipped, 16 warnings.
- Pre-commit, Ruff, and git diff --cached --check passed.

Residual limits:
- P-2 evaluator-level speedup remains unmeasured.
- Performance measurements cover one macOS arm64 host.
- Distributed Gloo modules were excluded because sandbox loopback networking is blocked.

---

part of #80 