### PR TITLE
perf(api): partition ignore ordering linearly [boost 3.77x]

### DIFF
--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -53,20 +53,24 @@ void SortInstancesByIgnore(
     std::vector<bool>* ignores) {
         ignores->clear();
         ignores->reserve(ground_truth_instances.size());
-        for (auto o : ground_truth_instances) {
-                ignores->emplace_back(o.ignore || o.area < area_range[0] ||
-                                      o.area > area_range[1]);
+        size_t non_ignored_count = 0;
+        for (const auto& o : ground_truth_instances) {
+                const bool ignore = o.ignore || o.area < area_range[0] ||
+                                    o.area > area_range[1];
+                ignores->emplace_back(ignore);
+                non_ignored_count += !ignore;
         }
 
+        // A boolean key needs only two stable buckets; direct placement avoids
+        // comparison sorting while preserving input order inside each bucket.
         ground_truth_sorted_indices->resize(ground_truth_instances.size());
-        std::iota(ground_truth_sorted_indices->begin(),
-                  ground_truth_sorted_indices->end(), 0);
-        std::stable_sort(ground_truth_sorted_indices->begin(),
-                         ground_truth_sorted_indices->end(),
-                         [&ignores](size_t j1, size_t j2) {
-                                 return (int)(*ignores)[j1] <
-                                        (int)(*ignores)[j2];
-                         });
+        size_t non_ignored_index = 0;
+        size_t ignored_index = non_ignored_count;
+        for (size_t index = 0; index < ignores->size(); ++index) {
+                const size_t output_index =
+                    (*ignores)[index] ? ignored_index++ : non_ignored_index++;
+                (*ground_truth_sorted_indices)[output_index] = index;
+        }
 }
 
 // For each IOU threshold, greedily match each detected instance to a ground

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -293,6 +293,48 @@ class TestBaseCoco(unittest.TestCase):
 
         self.assertEqual(len(evaluations), 1)
 
+    def test_evaluate_images_stably_partitions_ignored_ground_truth(self):
+        """Preserve ground-truth order within non-ignored and ignored
+        buckets."""
+        gt_dataset = _C.Dataset()
+        dt_dataset = _C.Dataset()
+        for annotation in [
+            {"id": 11, "area": 100.0, "ignore": False, "is_crowd": False},
+            {"id": 12, "area": 1.0, "ignore": False, "is_crowd": False},
+            {"id": 13, "area": 100.0, "ignore": True, "is_crowd": False},
+            {"id": 14, "area": 100.0, "ignore": False, "is_crowd": False},
+        ]:
+            gt_dataset.append(1, 1, annotation)
+        for annotation in [
+            {"id": 21, "score": 0.9, "area": 100.0, "ignore": False, "is_crowd": False},
+            {"id": 22, "score": 0.8, "area": 100.0, "ignore": False, "is_crowd": False},
+        ]:
+            dt_dataset.append(1, 1, annotation)
+
+        evaluation = _C.COCOevalEvaluateImages(
+            [[10.0, 200.0]],
+            100,
+            [0.5],
+            [[[[0.9] * 4, [0.9] * 4]]],
+            gt_dataset,
+            dt_dataset,
+            [1],
+            [1],
+            True,
+        )[0]
+
+        self.assertEqual(
+            evaluation.__getstate__(),
+            (
+                [14, 11],
+                [22, 21, 0, 0],
+                [0.9, 0.8],
+                [False, False, True, True],
+                [False, False],
+                [(21, 14, 0.9), (22, 11, 0.9)],
+            ),
+        )
+
     def test_evaluate_images_validates_merged_category_iou_shape(self):
         """Validate IoU dimensions after categories are merged."""
         gt_dataset = _C.Dataset()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -315,7 +315,7 @@ class TestBaseCoco(unittest.TestCase):
             [[10.0, 200.0]],
             100,
             [0.5],
-            [[[[0.9] * 4, [0.9] * 4]]],
+            [[[[0.9] * 4, [0.1, 0.9, 0.9, 0.9]]]],
             gt_dataset,
             dt_dataset,
             [1],
@@ -326,12 +326,12 @@ class TestBaseCoco(unittest.TestCase):
         self.assertEqual(
             evaluation.__getstate__(),
             (
-                [14, 11],
-                [22, 21, 0, 0],
+                [14, 13],
+                [0, 21, 0, 22],
                 [0.9, 0.8],
                 [False, False, True, True],
-                [False, False],
-                [(21, 14, 0.9), (22, 11, 0.9)],
+                [False, True],
+                [(21, 14, 0.9), (22, 13, 0.9)],
             ),
         )
 


### PR DESCRIPTION
Changes:
- Iterate ground-truth annotations by const reference and replace boolean-key stable_sort with stable O(G) two-bucket index placement.
- Add native evaluator characterization covering non-ignored, area-ignored, and explicitly ignored ground truths.

Impact:
- Reduce the measured exact helper from 95.929459 ms to 6.912209 ms (13.88x) and the native evaluator from 38.570708 ms to 10.231917 ms (3.77x).
- Preserve evaluator ordering and output digests while removing repeated annotation copies and O(G log G) comparison sorting.

Verification:
- Optimized isolated and in-place native extension builds passed.
- Seven alternating benchmark rounds produced identical exact-helper and evaluator digests.
- Focused characterization passed; extensive pycocotools parity passed 14 tests.
- Non-distributed suite passed 142 tests with 2 skipped and 2 Gloo tests deselected.
- Pre-commit lint/format and Codex Rig review/artifact validation passed.

Residual limits:
- Two distributed Gloo tests require a loopback-capable runner; this sandbox denies loopback socket creation.
- Performance measurements use a ground-truth-heavy synthetic workload and should not be generalized to small/default datasets.

---

part of #80