### PR TITLE
perf(api): parallelize image evaluation [boost 2.17x]

### DIFF
--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -1,10 +1,14 @@
 #include <time.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
+#include <exception>
+#include <future>
 #include <numeric>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 
 // clang-format off
 #include "cocoeval.h"
@@ -207,15 +211,13 @@ std::vector<ImageEvaluation> EvaluateImages(
                 throw std::runtime_error(error.str());
         }
 
-        std::vector<uint64_t> detection_sorted_indices;
-        std::vector<uint64_t> ground_truth_sorted_indices;
-        std::vector<bool> ignores;
-        std::vector<ImageEvaluation> results_all(num_images * num_area_ranges *
-                                                 num_categories);
+        // Convert Python-backed annotations before evaluation so the matching
+        // loop reads only stable C++ values.
+        const auto image_category_ground_truth_instances =
+            gt_dataset.get_cpp_instances(img_ids, cat_ids, useCats);
+        const auto image_category_detection_instances =
+            dt_dataset.get_cpp_instances(img_ids, cat_ids, useCats);
 
-        // Store results for each image, category, and area range combination.
-        // Results for each IOU threshold are packed into the same
-        // ImageEvaluation object
         for (auto i = 0; i < num_images; ++i) {
                 if (image_category_ious[i].size() !=
                     static_cast<std::size_t>(num_categories)) {
@@ -228,142 +230,150 @@ std::vector<ImageEvaluation> EvaluateImages(
                               << image_category_ious[i].size() << ".";
                         throw std::runtime_error(error.str());
                 }
+        }
 
-                for (auto c = 0; c < num_categories; ++c) {
-                        // Read annotations on-demand from datasets
-                        double img_id = img_ids[i];
+        // The preloaded vectors own their data, so cache entries can be
+        // released before evaluation without touching shared maps later.
+        for (const double img_id : img_ids) {
+                for (const double cat_id : cat_ids) {
+                        gt_dataset.clear_cache_entry(img_id, cat_id);
+                        dt_dataset.clear_cache_entry(img_id, cat_id);
+                }
+        }
 
-                        std::vector<InstanceAnnotation> ground_truth_instances;
-                        std::vector<InstanceAnnotation> detection_instances;
+        std::vector<ImageEvaluation> results_all(num_images * num_area_ranges *
+                                                 num_categories);
 
+        auto evaluate_image_category = [&](const std::size_t task_index) {
+                const auto i = static_cast<int>(task_index / num_categories);
+                const auto c = static_cast<int>(task_index % num_categories);
+                const double img_id = img_ids[i];
+                const auto& ground_truth_instances =
+                    image_category_ground_truth_instances[i][c];
+                const auto& detection_instances =
+                    image_category_detection_instances[i][c];
+                std::vector<uint64_t> detection_sorted_indices;
+                std::vector<uint64_t> ground_truth_sorted_indices;
+                std::vector<bool> ignores;
+
+                SortInstancesByDetectionScore(detection_instances,
+                                              &detection_sorted_indices);
+                if ((int)detection_sorted_indices.size() > max_detections) {
+                        detection_sorted_indices.resize(max_detections);
+                }
+
+                const auto& category_ious = image_category_ious[i][c];
+                const std::size_t expected_ground_truth =
+                    ground_truth_instances.size();
+                const std::size_t expected_detections =
+                    expected_ground_truth == 0 ||
+                            detection_sorted_indices.empty()
+                        ? 0
+                        : detection_sorted_indices.size();
+
+                if (category_ious.size() != expected_detections) {
+                        std::ostringstream error;
+                        error << "image_category_ious[" << i << "][" << c
+                              << "] for image id " << img_id;
                         if (useCats) {
-                                double cat_id = cat_ids[c];
-                                ground_truth_instances =
-                                    gt_dataset.get_cpp_annotations(img_id,
-                                                                   cat_id);
-                                detection_instances =
-                                    dt_dataset.get_cpp_annotations(img_id,
-                                                                   cat_id);
+                                error << " and category id " << cat_ids[c];
                         } else {
-                                // When useCats=False, merge all categories for
-                                // this image
-                                for (size_t j = 0; j < cat_ids.size(); ++j) {
-                                        double cat_id = cat_ids[j];
-                                        std::vector<InstanceAnnotation>
-                                            gt_anns =
-                                                gt_dataset.get_cpp_annotations(
-                                                    img_id, cat_id);
-                                        std::vector<InstanceAnnotation>
-                                            dt_anns =
-                                                dt_dataset.get_cpp_annotations(
-                                                    img_id, cat_id);
-
-                                        ground_truth_instances.insert(
-                                            ground_truth_instances.end(),
-                                            std::make_move_iterator(
-                                                gt_anns.begin()),
-                                            std::make_move_iterator(
-                                                gt_anns.end()));
-                                        detection_instances.insert(
-                                            detection_instances.end(),
-                                            std::make_move_iterator(
-                                                dt_anns.begin()),
-                                            std::make_move_iterator(
-                                                dt_anns.end()));
-                                }
+                                error << " with merged categories";
                         }
+                        error << " has an invalid detection dimension; "
+                                 "expected "
+                              << expected_detections << ", got "
+                              << category_ious.size() << ".";
+                        throw std::runtime_error(error.str());
+                }
 
-                        SortInstancesByDetectionScore(
-                            detection_instances, &detection_sorted_indices);
-                        if ((int)detection_sorted_indices.size() >
-                            max_detections) {
-                                detection_sorted_indices.resize(max_detections);
-                        }
-
-                        const auto& category_ious = image_category_ious[i][c];
-                        const std::size_t expected_ground_truth =
-                            ground_truth_instances.size();
-                        const std::size_t expected_detections =
-                            expected_ground_truth == 0 ||
-                                    detection_sorted_indices.empty()
-                                ? 0
-                                : detection_sorted_indices.size();
-
-                        if (category_ious.size() != expected_detections) {
+                for (std::size_t d = 0; d < category_ious.size(); ++d) {
+                        if (category_ious[d].size() != expected_ground_truth) {
                                 std::ostringstream error;
                                 error << "image_category_ious[" << i << "]["
-                                      << c << "] for image id " << img_id;
+                                      << c << "][" << d << "] for image id "
+                                      << img_id;
                                 if (useCats) {
                                         error << " and category id "
                                               << cat_ids[c];
                                 } else {
                                         error << " with merged categories";
                                 }
-                                error << " has an invalid detection dimension; "
-                                         "expected "
-                                      << expected_detections << ", got "
-                                      << category_ious.size() << ".";
+                                error << " has an invalid ground-truth "
+                                         "dimension; expected "
+                                      << expected_ground_truth << ", got "
+                                      << category_ious[d].size() << ".";
                                 throw std::runtime_error(error.str());
                         }
+                }
 
-                        for (std::size_t d = 0; d < category_ious.size(); ++d) {
-                                if (category_ious[d].size() !=
-                                    expected_ground_truth) {
-                                        std::ostringstream error;
-                                        error << "image_category_ious[" << i
-                                              << "][" << c << "][" << d
-                                              << "] for image id " << img_id;
-                                        if (useCats) {
-                                                error << " and category id "
-                                                      << cat_ids[c];
-                                        } else {
-                                                error << " with merged "
-                                                         "categories";
+                for (size_t a = 0; a < area_ranges.size(); ++a) {
+                        SortInstancesByIgnore(
+                            area_ranges[a], ground_truth_instances,
+                            &ground_truth_sorted_indices, &ignores);
+
+                        MatchDetectionsToGroundTruth(
+                            detection_instances, detection_sorted_indices,
+                            ground_truth_instances, ground_truth_sorted_indices,
+                            ignores, category_ious, iou_thresholds,
+                            area_ranges[a],
+                            &results_all[c * num_area_ranges * num_images +
+                                         a * num_images + i]);
+                }
+        };
+
+        const std::size_t num_tasks =
+            static_cast<std::size_t>(num_images) * num_categories;
+        if (num_tasks == 0) {
+                return results_all;
+        }
+
+        const std::size_t worker_count = std::min<std::size_t>(
+            num_tasks, std::max(1u, std::thread::hardware_concurrency()));
+        std::exception_ptr first_exception;
+        {
+                py::gil_scoped_release release;
+                if (worker_count == 1) {
+                        try {
+                                evaluate_image_category(0);
+                        } catch (...) {
+                                first_exception = std::current_exception();
+                        }
+                } else {
+                        std::atomic<std::size_t> next_task{0};
+                        auto evaluate_tasks = [&]() {
+                                while (true) {
+                                        const std::size_t task_index =
+                                            next_task.fetch_add(1);
+                                        if (task_index >= num_tasks) {
+                                                return;
                                         }
-                                        error << " has an invalid ground-truth "
-                                                 "dimension; expected "
-                                              << expected_ground_truth
-                                              << ", got "
-                                              << category_ious[d].size() << ".";
-                                        throw std::runtime_error(error.str());
+                                        evaluate_image_category(task_index);
                                 }
+                        };
+
+                        std::vector<std::future<void>> futures;
+                        futures.reserve(worker_count);
+                        for (std::size_t worker = 0; worker < worker_count;
+                             ++worker) {
+                                futures.emplace_back(std::async(
+                                    std::launch::async, evaluate_tasks));
                         }
 
-                        for (size_t a = 0; a < area_ranges.size(); ++a) {
-                                SortInstancesByIgnore(
-                                    area_ranges[a], ground_truth_instances,
-                                    &ground_truth_sorted_indices, &ignores);
-
-                                MatchDetectionsToGroundTruth(
-                                    detection_instances,
-                                    detection_sorted_indices,
-                                    ground_truth_instances,
-                                    ground_truth_sorted_indices, ignores,
-                                    category_ious, iou_thresholds,
-                                    area_ranges[a],
-                                    &results_all[c * num_area_ranges *
-                                                     num_images +
-                                                 a * num_images + i]);
-                        }
-
-                        // Clear cache entries to free memory after processing
-                        // all area_ranges
-                        if (useCats) {
-                                double cat_id = cat_ids[c];
-                                gt_dataset.clear_cache_entry(img_id, cat_id);
-                                dt_dataset.clear_cache_entry(img_id, cat_id);
-                        } else {
-                                // When useCats=False, clear cache for all
-                                // categories used
-                                for (size_t j = 0; j < cat_ids.size(); ++j) {
-                                        double cat_id = cat_ids[j];
-                                        gt_dataset.clear_cache_entry(img_id,
-                                                                     cat_id);
-                                        dt_dataset.clear_cache_entry(img_id,
-                                                                     cat_id);
+                        for (auto& future : futures) {
+                                try {
+                                        future.get();
+                                } catch (...) {
+                                        if (!first_exception) {
+                                                first_exception =
+                                                    std::current_exception();
+                                        }
                                 }
                         }
                 }
+        }
+        if (first_exception) {
+                std::rethrow_exception(first_exception);
         }
 
         return results_all;

--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -334,10 +334,15 @@ std::vector<ImageEvaluation> EvaluateImages(
         {
                 py::gil_scoped_release release;
                 if (worker_count == 1) {
-                        try {
-                                evaluate_image_category(0);
-                        } catch (...) {
-                                first_exception = std::current_exception();
+                        for (std::size_t task_index = 0; task_index < num_tasks;
+                             ++task_index) {
+                                try {
+                                        evaluate_image_category(task_index);
+                                } catch (...) {
+                                        first_exception =
+                                            std::current_exception();
+                                        break;
+                                }
                         }
                 } else {
                         std::atomic<std::size_t> next_task{0};

--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -222,7 +222,7 @@ void LightweightDataset::clear_cache_entry(double img_id, double cat_id) const {
 std::vector<std::vector<std::vector<InstanceAnnotation>>>
 LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
                                       const std::vector<double>& cat_ids,
-                                      const bool& useCats) {
+                                      const bool& useCats) const {
         std::vector<std::vector<std::vector<InstanceAnnotation>>> result;
         result.reserve(img_ids.size());  // Reserve space for image indices
 

--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -181,8 +181,9 @@ InstanceAnnotation LightweightDataset::parse_py_annotation(
 }
 
 // Get C++ annotation objects with caching for performance
-std::vector<InstanceAnnotation> LightweightDataset::get_cpp_annotations(
+const std::vector<InstanceAnnotation>& LightweightDataset::get_cpp_annotations(
     double img_id, double cat_id) const {
+        static const std::vector<InstanceAnnotation> kEmpty;
         const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
                                               static_cast<int64_t>(cat_id));
 
@@ -204,10 +205,10 @@ std::vector<InstanceAnnotation> LightweightDataset::get_cpp_annotations(
                 }
 
                 // Cache the result for future use
-                cpp_cache[key] = result;
-                return result;
+                auto inserted = cpp_cache.emplace(key, std::move(result));
+                return inserted.first->second;
         } else {
-                return {};
+                return kEmpty;
         }
 }
 

--- a/csrc/faster_eval_api/coco_eval/dataset.h
+++ b/csrc/faster_eval_api/coco_eval/dataset.h
@@ -64,7 +64,7 @@ class LightweightDataset {
         std::vector<std::vector<std::vector<InstanceAnnotation>>>
         get_cpp_instances(const std::vector<double>& img_ids,
                           const std::vector<double>& cat_ids,
-                          const bool& useCats);
+                          const bool& useCats) const;
 
         // Get all Python dict annotations for provided img_ids and cat_ids
         std::vector<std::vector<std::vector<py::dict>>> get_instances(

--- a/csrc/faster_eval_api/coco_eval/dataset.h
+++ b/csrc/faster_eval_api/coco_eval/dataset.h
@@ -54,7 +54,7 @@ class LightweightDataset {
         std::vector<py::dict> get(double img_id, double cat_id);
 
         // Get C++ annotation objects with caching for performance
-        std::vector<InstanceAnnotation> get_cpp_annotations(
+        const std::vector<InstanceAnnotation>& get_cpp_annotations(
             double img_id, double cat_id) const;
 
         // Clear cache entry for specific (img_id, cat_id) to free memory

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -293,6 +293,78 @@ class TestBaseCoco(unittest.TestCase):
 
         self.assertEqual(len(evaluations), 1)
 
+    def test_evaluate_images_matches_independent_image_category_calls(self):
+        """Match multi-pair evaluation to the equivalent independent calls."""
+        gt_dataset = _C.Dataset()
+        dt_dataset = _C.Dataset()
+        image_ids = [1, 2]
+        category_ids = [1, 2]
+        ious_by_pair = {}
+
+        for image_id in image_ids:
+            for category_id in category_ids:
+                annotation_offset = image_id * 100 + category_id * 10
+                for index in range(2):
+                    gt_dataset.append(
+                        image_id,
+                        category_id,
+                        {
+                            "id": annotation_offset + index,
+                            "area": 25.0 + index * 100.0,
+                            "ignore": False,
+                            "is_crowd": False,
+                        },
+                    )
+                    dt_dataset.append(
+                        image_id,
+                        category_id,
+                        {
+                            "id": 1000 + annotation_offset + index,
+                            "score": 0.9 - index * 0.1,
+                            "area": 25.0 + index * 100.0,
+                            "ignore": False,
+                            "is_crowd": False,
+                        },
+                    )
+                ious_by_pair[image_id, category_id] = [[0.9, 0.1], [0.2, 0.8]]
+
+        area_ranges = [[0.0, float("inf")], [0.0, 50.0]]
+        all_ious = [[ious_by_pair[image_id, category_id] for category_id in category_ids] for image_id in image_ids]
+        combined = _C.COCOevalEvaluateImages(
+            area_ranges,
+            100,
+            [0.5, 0.75],
+            all_ious,
+            gt_dataset,
+            dt_dataset,
+            image_ids,
+            category_ids,
+            True,
+        )
+
+        independent = {}
+        for image_id in image_ids:
+            for category_id in category_ids:
+                independent[image_id, category_id] = _C.COCOevalEvaluateImages(
+                    area_ranges,
+                    100,
+                    [0.5, 0.75],
+                    [[ious_by_pair[image_id, category_id]]],
+                    gt_dataset,
+                    dt_dataset,
+                    [image_id],
+                    [category_id],
+                    True,
+                )
+
+        expected = [
+            independent[image_id, category_id][area_index].__getstate__()
+            for category_id in category_ids
+            for area_index in range(len(area_ranges))
+            for image_id in image_ids
+        ]
+        self.assertEqual([evaluation.__getstate__() for evaluation in combined], expected)
+
     def test_evaluate_images_validates_merged_category_iou_shape(self):
         """Validate IoU dimensions after categories are merged."""
         gt_dataset = _C.Dataset()


### PR DESCRIPTION
Changes:
- Preload Python-backed annotations into owned C++ values, validate nested IoU dimensions, and clear evaluator caches before native matching.
- Evaluate flattened image-category tasks with task-local scratch across a bounded std::async worker set while the Python GIL is released.
- Capture worker failures and rethrow them only after reacquiring the GIL, preserving Python exception handling.
- Add a regression test that compares combined multi-image, multi-category output with independent calls across multiple area ranges.

Impact:
- COCOevalEvaluateImages runs the recorded workload in 0.030528 s median versus 0.066154 s on main https://github.com/MiXaiLL76/faster_coco_eval/commit/6d6ac357522d5305d923eb36a7e9b81bc8e4de4e, a 2.17x speedup.
- Serial and parallel builds produce the identical SHA-256 result digest 9accfe83eeb7df5bec9701b336f90a4703aa08623c6f0609012f003120cb3003.
- Public Python signatures and category-area-image result ordering remain unchanged.

Verification:
- python setup.py build_ext --inplace: passed on main and candidate.
- pre-commit on all four changed files: passed.
- checkout-local tests/test_dataset.py: 15 passed.
- checkout-local tests/test_extensive_pycocotools_comparison.py: 14 passed with 14 pre-existing annotation-id warnings.
- checkout-local full pytest outside sandbox networking restrictions: 144 passed, 2 skipped, 16 warnings.
- Five alternating main/candidate benchmark rounds, 1 warmup and 7 samples per process: 0.066154 s to 0.030528 s, 2.17x, identical digests.

Residual limits:
- TSan/ASan evidence remains required by the P-6 verification matrix and unavailable on this macOS host.
- Performance evidence covers one synthetic workload on one macOS arm64 host.
- Checkout-local PYTHONPATH is required to avoid the separately observed editable-import contamination.

---

part of #80
