### PR TITLE
perf(api): vectorize computeOks [boost 6.05x]

### DIFF
--- a/faster_coco_eval/core/cocoeval.py
+++ b/faster_coco_eval/core/cocoeval.py
@@ -307,7 +307,11 @@ class COCOeval:
         ious = np.zeros((len(dts), len(gts)))
         sigmas = p.kpt_oks_sigmas
         vars = (sigmas * 2) ** 2
-        k = len(sigmas)
+        # Load each detection once so every ground truth can operate on the
+        # same (detections, keypoints) arrays instead of rebuilding them.
+        detection_keypoints = np.asarray([dt["keypoints"] for dt in dts])
+        xd = detection_keypoints[:, 0::3]
+        yd = detection_keypoints[:, 1::3]
         # compute oks between each detection and ground truth object
         for j, gt in enumerate(gts):
             # create bounds for ignore regions(double the gt bbox)
@@ -321,29 +325,27 @@ class COCOeval:
             x1 = bb[0] + bb[2] * 2
             y0 = bb[1] - bb[3]
             y1 = bb[1] + bb[3] * 2
-            for i, dt in enumerate(dts):
-                d = np.array(dt["keypoints"])
-                xd = d[0::3]
-                yd = d[1::3]
-                if k1 > 0:
-                    # measure the per-keypoint distance if keypoints visible
-                    dx = xd - xg
-                    dy = yd - yg
-                else:
-                    # measure minimum distance to keypoints in (x0,y0) & (x1,y1)
-                    z = np.zeros(k)
-                    dx = np.max((z, x0 - xd), axis=0) + np.max((z, xd - x1), axis=0)
-                    dy = np.max((z, y0 - yd), axis=0) + np.max((z, yd - y1), axis=0)
+            if k1 > 0:
+                # Keep the visible-keypoint mask as columns for every
+                # detection row so the per-keypoint reduction is unchanged.
+                dx = xd - xg
+                dy = yd - yg
+            else:
+                z = np.zeros_like(xd)
+                dx = np.max((z, x0 - xd), axis=0) + np.max((z, xd - x1), axis=0)
+                dy = np.max((z, y0 - yd), axis=0) + np.max((z, yd - y1), axis=0)
 
-                if self.use_area:
-                    e = (dx**2 + dy**2) / vars / (gt["area"] + np.spacing(1)) / 2
-                else:
-                    tmparea = gt["bbox"][3] * gt["bbox"][2] * 0.53
-                    e = (dx**2 + dy**2) / vars / (tmparea + np.spacing(1)) / 2
+            if self.use_area:
+                e = (dx**2 + dy**2) / vars / (gt["area"] + np.spacing(1)) / 2
+            else:
+                tmparea = gt["bbox"][3] * gt["bbox"][2] * 0.53
+                e = (dx**2 + dy**2) / vars / (tmparea + np.spacing(1)) / 2
 
-                if k1 > 0:
-                    e = e[vg > 0]
-                ious[i, j] = np.sum(np.exp(-e)) / e.shape[0]
+            if k1 > 0:
+                e = e[:, vg > 0]
+            # Retain the baseline's one-dimensional reduction order so this
+            # vectorized path remains bit-identical to the public evaluator.
+            ious[:, j] = [np.sum(row) / row.shape[0] for row in np.exp(-e)]
         return ious
 
     def evaluateImg(self, imgId, catId, aRng, maxDet):

--- a/tests/test_compute_oks.py
+++ b/tests/test_compute_oks.py
@@ -1,0 +1,69 @@
+"""Regression coverage for vectorized Object Keypoint Similarity
+computation."""
+
+import numpy as np
+
+from faster_coco_eval import COCO
+from faster_coco_eval.core.cocoeval import COCOeval
+
+
+def test_compute_oks_preserves_visible_and_unlabeled_ground_truth_rows():
+    """Keep fixed OKS values for visible and unlabeled ground-truth
+    keypoints."""
+    ground_truth = {
+        "images": [{"id": 1, "width": 100, "height": 100}],
+        "categories": [{"id": 1, "name": "person"}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [0.0, 0.0, 30.0, 30.0],
+                "area": 900.0,
+                "iscrowd": 0,
+                "keypoints": [10.0, 10.0, 2, 20.0, 20.0, 1, 0.0, 0.0, 0],
+                "num_keypoints": 2,
+            },
+            {
+                "id": 2,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [20.0, 20.0, 10.0, 10.0],
+                "area": 100.0,
+                "iscrowd": 0,
+                "keypoints": [0.0, 0.0, 0, 0.0, 0.0, 0, 0.0, 0.0, 0],
+                "num_keypoints": 0,
+            },
+        ],
+    }
+    detections = [
+        {
+            "image_id": 1,
+            "category_id": 1,
+            "score": 0.9,
+            "keypoints": [11.0, 9.0, 2, 18.0, 22.0, 2, 30.0, 30.0, 2],
+        },
+        {
+            "image_id": 1,
+            "category_id": 1,
+            "score": 0.8,
+            "keypoints": [0.0, 0.0, 2, 0.0, 0.0, 2, 0.0, 0.0, 2],
+        },
+        {
+            "image_id": 1,
+            "category_id": 1,
+            "score": 0.7,
+            "keypoints": [40.0, 40.0, 2, 40.0, 40.0, 2, 40.0, 40.0, 2],
+        },
+    ]
+    coco_gt = COCO(ground_truth)
+    evaluator = COCOeval(coco_gt, coco_gt.loadRes(detections), "keypoints", kpt_oks_sigmas=[0.1, 0.1, 0.1])
+    evaluator.params.maxDets = [3]
+    evaluator._prepare()
+
+    expected = np.array([
+        [0.9337218969653591, 0.9608323008615317],
+        [0.031095734680320564, 1.388794386496407e-11],
+        [7.4726762063626715e-06, 1.0],
+    ])
+    np.testing.assert_array_equal(evaluator.computeOks(1, 1), expected)


### PR DESCRIPTION
Changes:
- Stack detection keypoints once and vectorize each ground truth comparison across detections.
- Preserve baseline per-row reduction order and add visible/unlabeled keypoint regression coverage.

Impact:
- Fixed direct computeOks workload improved from 0.023877019 s to 0.003949417 s (6.05x) with bit-identical output.

Verification:
- pre-commit run --files faster_coco_eval/core/cocoeval.py tests/test_compute_oks.py
- python -m pytest -p no:rerunfailures -q (147 passed, 2 skipped)

Residual limits:
- Performance evidence covers one macOS arm64 direct-call workload; CI and broader workload coverage remain unobserved.

---

part of #80