### PR TITLE
perf(api): optimize native and annotation dispatch

### DIFF
--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -582,18 +582,16 @@ std::vector<double> _preproc_bbox_array(const py::object& pyobj) {
 //   - std::out_of_range if the input type is unsupported or malformed.
 std::tuple<std::variant<std::vector<RLE>, std::vector<double>>, size_t>
 _preproc(const py::object& pyobj) {
-        std::string type = py::str(py::type::of(pyobj));
-        if (type == "<class 'numpy.ndarray'>") {
+        if (py::isinstance<py::array>(pyobj)) {
                 auto result = _preproc_bbox_array(pyobj);
                 return {result, result.size() / 4};
-        } else if (type == "<class 'list'>") {
+        } else if (py::isinstance<py::list>(pyobj)) {
                 auto pyobj_list = pyobj.cast<std::vector<py::object>>();
                 if (pyobj_list.empty()) {
                         return {std::vector<double>{}, 0};
                 }
-                std::string sub_type = py::str(py::type::of(pyobj_list[0]));
-                if (sub_type == "<class 'list'>" ||
-                    sub_type == "<class 'numpy.ndarray'>") {
+                if (py::isinstance<py::list>(pyobj_list[0]) ||
+                    py::isinstance<py::array>(pyobj_list[0])) {
                         auto matrix =
                             pyobj.cast<std::vector<std::vector<double>>>();
                         for (const auto& item : matrix) {
@@ -612,7 +610,7 @@ _preproc(const py::object& pyobj) {
                         return {result, result.size() / 4};
                 }
         check_rle:
-                if (sub_type == "<class 'dict'>") {
+                if (py::isinstance<py::dict>(pyobj_list[0])) {
                         auto result =
                             _frString(pyobj.cast<std::vector<py::dict>>());
                         return {result, result.size()};
@@ -695,27 +693,24 @@ std::variant<py::array_t<double, py::array::f_style>, std::vector<double>> iou(
 std::variant<pybind11::dict, std::vector<pybind11::dict>> frPyObjects(
     const py::object& pyobj, const uint64_t& h, const uint64_t& w) {
         std::vector<RLE> rles;
-        std::string type = py::str(py::type::of(pyobj));
 
         // Handle Python list input
-        if (type == "<class 'list'>") {
+        if (py::isinstance<py::list>(pyobj)) {
                 std::vector<py::object> pyobj_list =
                     pyobj.cast<std::vector<py::object>>();
                 if (pyobj_list.size() == 0) {
                         throw std::out_of_range("list index out of range");
                 }
 
-                std::string sub_type = py::str(py::type::of(pyobj_list[0]));
-
                 // List of dicts: treat as uncompressed RLEs
-                if (sub_type == "<class 'dict'>") {
+                if (py::isinstance<py::dict>(pyobj_list[0])) {
                         return frUncompressedRLE(
                             pyobj.cast<std::vector<py::dict>>());
                 }
                 // List of lists or numpy arrays: treat as bbox or polygon
                 // depending on shape
-                else if ((sub_type == "<class 'list'>") ||
-                         (sub_type == "<class 'numpy.ndarray'>")) {
+                else if (py::isinstance<py::list>(pyobj_list[0]) ||
+                         py::isinstance<py::array>(pyobj_list[0])) {
                         std::vector<std::vector<double>> numpy_array =
                             pyobj.cast<std::vector<std::vector<double>>>();
                         if (numpy_array[0].size() == 4) {
@@ -726,8 +721,8 @@ std::variant<pybind11::dict, std::vector<pybind11::dict>> frPyObjects(
                 }
                 // List of floats or ints: treat as a single bbox or polygon
                 // depending on length
-                else if ((sub_type == "<class 'float'>") ||
-                         (sub_type == "<class 'int'>")) {
+                else if (py::isinstance<py::float_>(pyobj_list[0]) ||
+                         py::isinstance<py::int_>(pyobj_list[0])) {
                         std::vector<double> array =
                             pyobj.cast<std::vector<double>>();
                         if (array.size() == 4) {
@@ -742,12 +737,12 @@ std::variant<pybind11::dict, std::vector<pybind11::dict>> frPyObjects(
                 }
         }
         // Handle numpy ndarray input as bounding boxes
-        else if (type == "<class 'numpy.ndarray'>") {
+        else if (py::isinstance<py::array>(pyobj)) {
                 return frBbox(pyobj.cast<std::vector<std::vector<double>>>(), h,
                               w);
         }
         // Handle single dict input as uncompressed RLE
-        else if (type == "<class 'dict'>") {
+        else if (py::isinstance<py::dict>(pyobj)) {
                 return frUncompressedRLE(
                     {pyobj})[0];  // Return the first (and only) dict
         } else {

--- a/faster_coco_eval/core/coco.py
+++ b/faster_coco_eval/core/coco.py
@@ -108,12 +108,22 @@ class COCO:
                 imgs[img["id"]] = img
 
         if "annotations" in self.dataset:
-            for ann in self.dataset["annotations"]:
-                if type(ann["image_id"]) is not int:
-                    ann["image_id"] = int(ann["image_id"])
+            # Preserve category-less datasets without branching for every normal COCO annotation.
+            if "categories" in self.dataset:
+                for ann in self.dataset["annotations"]:
+                    if type(ann["image_id"]) is not int:
+                        ann["image_id"] = int(ann["image_id"])
 
-                imgToAnns[ann["image_id"]].append(ann)
-                anns[ann["id"]] = ann
+                    imgToAnns[ann["image_id"]].append(ann)
+                    anns[ann["id"]] = ann
+                    catToImgs[ann["category_id"]].append(ann["image_id"])
+            else:
+                for ann in self.dataset["annotations"]:
+                    if type(ann["image_id"]) is not int:
+                        ann["image_id"] = int(ann["image_id"])
+
+                    imgToAnns[ann["image_id"]].append(ann)
+                    anns[ann["id"]] = ann
 
             if 0 in anns:
                 warnings.warn(
@@ -129,10 +139,6 @@ class COCO:
         if "categories" in self.dataset:
             for cat in self.dataset["categories"]:
                 cats[cat["id"]] = cat
-
-        if "annotations" in self.dataset and "categories" in self.dataset:
-            for ann in self.dataset["annotations"]:
-                catToImgs[ann["category_id"]].append(ann["image_id"])
 
         self.print_function("index created!")
         self.print_function(f"Done (t={time.time() - tic:0.2f}s)")

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -17,6 +17,18 @@ def _encode(x):
     return mask_util.encode(np.asfortranarray(x, np.uint8))
 
 
+class _ListSubclass(list):
+    """Exercise native dispatch with a Python list subclass."""
+
+
+class _DictSubclass(dict):
+    """Exercise native dispatch with a Python dict subclass."""
+
+
+class _ArraySubclass(np.ndarray):
+    """Exercise native dispatch with a NumPy array subclass."""
+
+
 class TestMaskApi(unittest.TestCase):
     maxDiff = None
 
@@ -232,6 +244,33 @@ class TestMaskApi(unittest.TestCase):
 
         result_poly_iou = module.iou(self.poly_rles[:3], self.poly_rles[:3], [0, 0, 0]).round(4)
         self.assertEqual(poly_iou.tolist(), result_poly_iou.tolist())
+
+    def test_iou_accepts_list_and_array_subclasses(self):
+        """Dispatch bounding boxes from list and NumPy array subclasses."""
+        expected = _mask.iou(self.bboxes[:2], self.bboxes[:2], [0, 0])
+        list_boxes = _ListSubclass(
+            [_ListSubclass(box) for box in self.bboxes[:2].tolist()],
+        )
+        array_boxes = self.bboxes[:2].view(_ArraySubclass)
+        rle_list = _ListSubclass([_DictSubclass(self.compressed_rle)])
+
+        np.testing.assert_array_equal(_mask.iou(list_boxes, list_boxes, [0, 0]), expected)
+        np.testing.assert_array_equal(_mask.iou(array_boxes, array_boxes, [0, 0]), expected)
+        np.testing.assert_array_equal(_mask.iou(rle_list, rle_list, [0]), np.ones((1, 1)))
+
+    def test_fr_py_objects_accepts_list_and_dict_subclasses(self):
+        """Dispatch segmentation input from list and dict subclasses."""
+        rle = _DictSubclass(self.uncompressed_rle)
+
+        self.assertEqual(
+            self.compressed_rle,
+            _mask.frPyObjects(_ListSubclass([rle]), 1350, 1080)[0],
+        )
+        self.assertEqual(self.compressed_rle, _mask.frPyObjects(rle, 1350, 1080))
+        self.assertEqual(
+            self.bbox_rles[:2],
+            _mask.frPyObjects(self.bboxes[:2].view(_ArraySubclass), 20, 20),
+        )
 
     def test_iou_releases_gil_during_cpp_compute(self):
         """Allow another Python thread to run during native IoU computation."""

--- a/tests/test_orphan_annotations.py
+++ b/tests/test_orphan_annotations.py
@@ -4,6 +4,24 @@ import unittest
 from faster_coco_eval import COCO
 
 
+class _SinglePassAnnotations(list):
+    """Reject a second iteration so the indexing pass remains single-pass."""
+
+    def __init__(self, annotations):
+        """Store annotations and track iterations requested by
+        `createIndex`."""
+        super().__init__(annotations)
+        self.iteration_count = 0
+
+    def __iter__(self):
+        """Yield annotations once, failing if an index rebuild traverses them
+        again."""
+        self.iteration_count += 1
+        if self.iteration_count > 1:
+            raise AssertionError("createIndex iterated annotations more than once")
+        return super().__iter__()
+
+
 class TestOrphanAnnotations(unittest.TestCase):
     """Verify annotations remain consistently indexed without image
     metadata."""
@@ -30,6 +48,40 @@ class TestOrphanAnnotations(unittest.TestCase):
         self.assertEqual(coco.loadAnns(annotation_ids), [annotation])
         self.assertEqual(coco.imgToAnns[annotation["image_id"]], [annotation])
         self.assertEqual(coco.catToImgs[annotation["category_id"]], [annotation["image_id"]])
+
+    def test_create_index_builds_all_annotation_indexes_in_one_pass(self):
+        """Build every annotation index during a single annotation
+        traversal."""
+        annotations = _SinglePassAnnotations([
+            {"id": 1, "image_id": 1, "category_id": 3},
+            {"id": 2, "image_id": 2, "category_id": 4},
+        ])
+        coco = COCO()
+        coco.dataset = {
+            "images": [{"id": 1}, {"id": 2}],
+            "categories": [{"id": 3}, {"id": 4}],
+            "annotations": annotations,
+        }
+
+        coco.createIndex()
+
+        self.assertEqual(annotations.iteration_count, 1)
+        self.assertEqual(list(coco.anns), [1, 2])
+        self.assertEqual(coco.imgToAnns[1], [annotations[0]])
+        self.assertEqual(coco.catToImgs[4], [2])
+
+    def test_create_index_skips_category_index_without_categories(self):
+        """Preserve the empty category index for category-less datasets."""
+        coco = COCO()
+        coco.dataset = {
+            "images": [{"id": 1}],
+            "annotations": [{"id": 1, "image_id": 1, "category_id": 3}],
+        }
+
+        coco.createIndex()
+
+        self.assertEqual(coco.imgToAnns[1], [{"id": 1, "image_id": 1, "category_id": 3}])
+        self.assertEqual(coco.catToImgs, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes:
- Replace stringified native-mask type comparisons with pybind11 isinstance checks.
- Add list, dict, and NumPy subclass regression coverage.
- Build annotation, image, and category indexes in one traversal while preserving category-less datasets.

Impact:
- Python subclasses follow their base-type mask API paths, and category-bearing COCO indexes avoid a second annotation pass.

Verification:
- python setup.py build_ext --inplace
- python -m pytest -p no:rerunfailures -q tests/test_mask_api.py (33 passed)
- python -m pytest -p no:rerunfailures -q tests/test_orphan_annotations.py (3 passed)
- python -m pytest -p no:rerunfailures -q (150 passed, 2 skipped)
- pre-commit run --files csrc/mask_api/src/mask.cpp tests/test_mask_api.py
- pre-commit run --files faster_coco_eval/core/coco.py tests/test_orphan_annotations.py

Residual limits:
- No microbenchmark; expected native dispatch benefit is below 2%.

---

part of #80
