### PR TITLE
perf(api): parallelize batch RLE ops [boost 2.80x]

### DIFF
--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -9,9 +9,11 @@ typedef std::ptrdiff_t ssize_t;
 #include <time.h>
 
 #include <algorithm>
+#include <condition_variable>
 #include <cstdint>
 #include <future>
 #include <iostream>
+#include <mutex>
 #include <numeric>
 #include <thread>
 #include <vector>
@@ -28,12 +30,59 @@ namespace {
 
 constexpr size_t kParallelBatchThreshold = 8;
 
+// Process-wide permit budget capping the total number of async batch workers
+// across all concurrent calls. Because callers release the GIL, several Python
+// threads may enter the batch APIs at once; without a shared bound each call
+// could spawn up to hardware_concurrency() OS threads, oversubscribing the
+// machine.
+class ParallelPermitPool {
+       public:
+        static size_t capacity() {
+                return std::max(
+                    size_t{1},
+                    static_cast<size_t>(std::thread::hardware_concurrency()));
+        }
+
+        explicit ParallelPermitPool(size_t size) : available(size) {}
+
+        // RAII permit; acquisition blocks until a slot is free.
+        class Permit {
+               public:
+                explicit Permit(ParallelPermitPool& pool) : pool(pool) {
+                        std::unique_lock<std::mutex> lock(pool.mutex);
+                        pool.condition.wait(lock, [&pool] {
+                                return pool.available > 0;
+                        });
+                        --pool.available;
+                }
+                ~Permit() {
+                        std::lock_guard<std::mutex> lock(pool.mutex);
+                        ++pool.available;
+                        pool.condition.notify_one();
+                }
+                Permit(Permit&&) = default;
+                Permit(const Permit&) = delete;
+                Permit& operator=(const Permit&) = delete;
+
+               private:
+                ParallelPermitPool& pool;
+        };
+
+       private:
+        std::mutex mutex;
+        std::condition_variable condition;
+        size_t available;
+};
+
+ParallelPermitPool& parallelPermitPool() {
+        static ParallelPermitPool pool(ParallelPermitPool::capacity());
+        return pool;
+}
+
 template <typename Function>
 void parallelFor(size_t count, Function&& function) {
-        const size_t workers = std::min(
-            count,
-            std::max(size_t{1},
-                     static_cast<size_t>(std::thread::hardware_concurrency())));
+        const size_t workers =
+            std::min(count, ParallelPermitPool::capacity());
         if (count < kParallelBatchThreshold || workers < 2) {
                 for (size_t index = 0; index < count; ++index) {
                         function(index);
@@ -41,17 +90,29 @@ void parallelFor(size_t count, Function&& function) {
                 return;
         }
 
+        // Always run the first chunk inline so the calling thread performs
+        // useful work while waiting on permits for the remaining chunks.
         const size_t chunk_size = (count + workers - 1) / workers;
         std::vector<std::future<void>> futures;
-        futures.reserve(workers);
-        for (size_t start = 0; start < count; start += chunk_size) {
+        futures.reserve(workers - 1);
+        for (size_t start = chunk_size; start < count; start += chunk_size) {
                 const size_t end = std::min(start + chunk_size, count);
+                // Bound applies process-wide: each async chunk must hold a
+                // shared permit before spawning its worker thread.
+                ParallelPermitPool::Permit permit(parallelPermitPool());
                 futures.emplace_back(
-                    std::async(std::launch::async, [&function, start, end]() {
-                            for (size_t index = start; index < end; ++index) {
-                                    function(index);
-                            }
-                    }));
+                    std::async(std::launch::async,
+                               [&function, start, end,
+                                permit = std::move(permit)]() mutable {
+                                       for (size_t index = start; index < end;
+                                            ++index) {
+                                               function(index);
+                                       }
+                               }));
+        }
+        const size_t first_end = std::min(chunk_size, count);
+        for (size_t index = 0; index < first_end; ++index) {
+                function(index);
         }
         for (auto& future : futures) {
                 future.get();

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -11,6 +11,7 @@ typedef std::ptrdiff_t ssize_t;
 #include <algorithm>
 #include <condition_variable>
 #include <cstdint>
+#include <exception>
 #include <future>
 #include <iostream>
 #include <mutex>
@@ -109,9 +110,18 @@ void parallelFor(size_t count, Function&& function) {
                             }
                     }));
         }
+        // Join every worker before surfacing a failure so no task's exception
+        // is silently discarded and the propagated error is deterministic.
+        std::exception_ptr first_error;
         for (auto& future : futures) {
-                future.get();
+                try {
+                        future.get();
+                } catch (...) {
+                        if (!first_error)
+                                first_error = std::current_exception();
+                }
         }
+        if (first_error) std::rethrow_exception(first_error);
 }
 
 }  // namespace

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -50,9 +50,8 @@ class ParallelPermitPool {
                public:
                 explicit Permit(ParallelPermitPool& pool) : pool(pool) {
                         std::unique_lock<std::mutex> lock(pool.mutex);
-                        pool.condition.wait(lock, [&pool] {
-                                return pool.available > 0;
-                        });
+                        pool.condition.wait(
+                            lock, [&pool] { return pool.available > 0; });
                         --pool.available;
                 }
                 ~Permit() {
@@ -81,8 +80,7 @@ ParallelPermitPool& parallelPermitPool() {
 
 template <typename Function>
 void parallelFor(size_t count, Function&& function) {
-        const size_t workers =
-            std::min(count, ParallelPermitPool::capacity());
+        const size_t workers = std::min(count, ParallelPermitPool::capacity());
         if (count < kParallelBatchThreshold || workers < 2) {
                 for (size_t index = 0; index < count; ++index) {
                         function(index);
@@ -100,15 +98,13 @@ void parallelFor(size_t count, Function&& function) {
                 // Bound applies process-wide: each async chunk must hold a
                 // shared permit before spawning its worker thread.
                 ParallelPermitPool::Permit permit(parallelPermitPool());
-                futures.emplace_back(
-                    std::async(std::launch::async,
-                               [&function, start, end,
-                                permit = std::move(permit)]() mutable {
-                                       for (size_t index = start; index < end;
-                                            ++index) {
-                                               function(index);
-                                       }
-                               }));
+                futures.emplace_back(std::async(
+                    std::launch::async, [&function, start, end,
+                                         permit = std::move(permit)]() mutable {
+                            for (size_t index = start; index < end; ++index) {
+                                    function(index);
+                            }
+                    }));
         }
         const size_t first_end = std::min(chunk_size, count);
         for (size_t index = 0; index < first_end; ++index) {

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -115,7 +115,7 @@ std::vector<RLE> rleEncode(const py::array_t<uint8_t, py::array::f_style>& M,
                                 }
                         }
                         cnts.emplace_back(count);
-                        rles[index] = RLE(h, w, cnts.size(), std::move(cnts));
+                        rles[index] = RLE(h, w, std::move(cnts));
                 });
         }
         return rles;

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -10,7 +10,6 @@ typedef std::ptrdiff_t ssize_t;
 
 #include <algorithm>
 #include <cstdint>
-#include <execution>
 #include <future>
 #include <iostream>
 #include <numeric>
@@ -24,6 +23,42 @@ using namespace pybind11::literals;
 namespace mask_api {
 
 namespace Mask {
+
+namespace {
+
+constexpr size_t kParallelBatchThreshold = 8;
+
+template <typename Function>
+void parallelFor(size_t count, Function&& function) {
+        const size_t workers = std::min(
+            count,
+            std::max(size_t{1},
+                     static_cast<size_t>(std::thread::hardware_concurrency())));
+        if (count < kParallelBatchThreshold || workers < 2) {
+                for (size_t index = 0; index < count; ++index) {
+                        function(index);
+                }
+                return;
+        }
+
+        const size_t chunk_size = (count + workers - 1) / workers;
+        std::vector<std::future<void>> futures;
+        futures.reserve(workers);
+        for (size_t start = 0; start < count; start += chunk_size) {
+                const size_t end = std::min(start + chunk_size, count);
+                futures.emplace_back(
+                    std::async(std::launch::async, [&function, start, end]() {
+                            for (size_t index = start; index < end; ++index) {
+                                    function(index);
+                            }
+                    }));
+        }
+        for (auto& future : futures) {
+                future.get();
+        }
+}
+
+}  // namespace
 
 // Converts an RLE object to a Python bytes object using its toString() method.
 py::bytes rleToString(const RLE& R) { return py::bytes(R.toString()); }
@@ -52,40 +87,36 @@ std::vector<RLE> rleEncode(const py::array_t<uint8_t, py::array::f_style>& M,
                            uint64_t h, uint64_t w, uint64_t n) {
         auto mask = M.unchecked<3>();
 
-        std::vector<RLE> rles;
-        rles.reserve(n);
+        std::vector<RLE> rles(n);
+        {
+                py::gil_scoped_release release;
+                parallelFor(n, [&](size_t index) {
+                        std::vector<uint64_t> cnts;
+                        const size_t min_reserve = 16;
+                        const size_t max_reserve = h * w / 4;
+                        const size_t perimeter_estimate = 2 * (h + w);
+                        cnts.reserve(std::max(
+                            min_reserve,
+                            std::min(max_reserve, perimeter_estimate)));
 
-        for (uint64_t i = 0; i < n; ++i) {
-                std::vector<uint64_t> cnts;
-                // Improved allocation strategy: adaptive sizing based on mask
-                // characteristics
-                size_t min_reserve = 16;  // Minimum reasonable size
-                size_t max_reserve =
-                    h * w / 4;  // Maximum for very complex masks
-                size_t perimeter_estimate =
-                    2 * (h + w);  // Typical perimeter-based estimate
-                size_t estimated_size = std::max(
-                    min_reserve, std::min(max_reserve, perimeter_estimate));
-                cnts.reserve(estimated_size);
-
-                uint8_t prev = 0;
-                uint64_t count = 0;
-
-                // Traverse the mask in column-major order
-                for (uint64_t row = 0; row < w; ++row) {
-                        for (uint64_t col = 0; col < h; ++col) {
-                                uint8_t value = mask(col, row, i);
-                                if (value != prev) {
-                                        cnts.emplace_back(count);
-                                        count = 0;
-                                        prev = value;
+                        uint8_t previous = 0;
+                        uint64_t count = 0;
+                        for (uint64_t row = 0; row < w; ++row) {
+                                for (uint64_t column = 0; column < h;
+                                     ++column) {
+                                        const uint8_t value =
+                                            mask(column, row, index);
+                                        if (value != previous) {
+                                                cnts.emplace_back(count);
+                                                count = 0;
+                                                previous = value;
+                                        }
+                                        ++count;
                                 }
-                                ++count;
                         }
-                }
-                cnts.emplace_back(count);
-
-                rles.emplace_back(h, w, cnts.size(), std::move(cnts));
+                        cnts.emplace_back(count);
+                        rles[index] = RLE(h, w, cnts.size(), std::move(cnts));
+                });
         }
         return rles;
 }
@@ -247,39 +278,47 @@ py::array_t<uint8_t, py::array::f_style> rleDecode(const std::vector<RLE>& R) {
             {static_cast<size_t>(h), static_cast<size_t>(w), n});
         auto mask = M.mutable_unchecked<3>();
 
-        for (size_t i = 0; i < n; ++i) {
-                uint8_t v = 0;
-                uint64_t x = 0, y = 0, c = 0;
+        {
+                py::gil_scoped_release release;
+                parallelFor(n, [&](size_t index) {
+                        uint8_t value = 0;
+                        uint64_t x = 0, y = 0, count = 0;
 
-                for (uint64_t j = 0; j < R[i].m; ++j) {
-                        for (uint64_t k = 0; k < R[i].cnts[j]; ++k) {
-                                if (c >= pixels_per_mask) {
-                                        std::stringstream ss;
-                                        ss << "Invalid RLE mask "
-                                              "representation; out of range "
-                                              "HxW=[0;0]->["
-                                           << h - 1 << ";" << w - 1
-                                           << "] x=" << x << "; y=" << y;
-                                        throw std::range_error(ss.str());
-                                }
+                        for (uint64_t run = 0; run < R[index].m; ++run) {
+                                for (uint64_t pixel = 0;
+                                     pixel < R[index].cnts[run]; ++pixel) {
+                                        if (count >= pixels_per_mask) {
+                                                std::stringstream ss;
+                                                ss << "Invalid RLE mask "
+                                                      "representation; out of "
+                                                      "range HxW=[0;0]->["
+                                                   << h - 1 << ";" << w - 1
+                                                   << "] x=" << x
+                                                   << "; y=" << y;
+                                                throw std::range_error(
+                                                    ss.str());
+                                        }
 
-                                mask(y, x, i) = v;
-                                ++c;
-                                ++y;
-                                if (y >= h) {
-                                        y = 0;
-                                        ++x;
+                                        mask(y, x, index) = value;
+                                        ++count;
+                                        ++y;
+                                        if (y >= h) {
+                                                y = 0;
+                                                ++x;
+                                        }
                                 }
+                                value = !value;
                         }
-                        v = !v;
-                }
-                if (c != pixels_per_mask) {
-                        std::stringstream ss;
-                        ss << "Invalid RLE mask representation; decoded " << c
-                           << " pixels but expected " << pixels_per_mask
-                           << " (h=" << h << ", w=" << w << ")";
-                        throw std::range_error(ss.str());
-                }
+                        if (count != pixels_per_mask) {
+                                std::stringstream ss;
+                                ss << "Invalid RLE mask representation; "
+                                      "decoded "
+                                   << count << " pixels but expected "
+                                   << pixels_per_mask << " (h=" << h
+                                   << ", w=" << w << ")";
+                                throw std::range_error(ss.str());
+                        }
+                });
         }
         return M;
 }
@@ -293,10 +332,14 @@ py::array_t<uint8_t, py::array::f_style> decode(
 std::vector<py::dict> erode_3x3(const std::vector<py::dict>& rleObjs,
                                 const int& dilation) {
         std::vector<RLE> rles = _frString(rleObjs);
-        std::transform(
-            rles.begin(), rles.end(), rles.begin(),
-            [dilation](const RLE& rle) { return rle.erode_3x3(dilation); });
-        return _toString(rles);
+        std::vector<RLE> eroded(rles.size());
+        {
+                py::gil_scoped_release release;
+                parallelFor(rles.size(), [&](size_t index) {
+                        eroded[index] = rles[index].erode_3x3(dilation);
+                });
+        }
+        return _toString(eroded);
 }
 
 std::vector<py::dict> toBoundary(const std::vector<py::dict>& rleObjs,
@@ -320,8 +363,12 @@ py::dict merge(const std::vector<py::dict>& rleObjs) {
 py::array_t<uint64_t> area(const std::vector<py::dict>& rleObjs) {
         std::vector<RLE> rles = _frString(rleObjs);
         std::vector<uint64_t> areas(rles.size());
-        std::transform(rles.begin(), rles.end(), areas.begin(),
-                       [](RLE const& rle) { return rle.area(); });
+        {
+                py::gil_scoped_release release;
+                parallelFor(rles.size(), [&](size_t index) {
+                        areas[index] = rles[index].area();
+                });
+        }
         return py::array(areas.size(), areas.data());
 }
 

--- a/csrc/mask_api/src/mask.cpp
+++ b/csrc/mask_api/src/mask.cpp
@@ -55,11 +55,12 @@ class ParallelPermitPool {
                         --pool.available;
                 }
                 ~Permit() {
-                        std::lock_guard<std::mutex> lock(pool.mutex);
-                        ++pool.available;
+                        {
+                                std::lock_guard<std::mutex> lock(pool.mutex);
+                                ++pool.available;
+                        }
                         pool.condition.notify_one();
                 }
-                Permit(Permit&&) = default;
                 Permit(const Permit&) = delete;
                 Permit& operator=(const Permit&) = delete;
 
@@ -88,27 +89,25 @@ void parallelFor(size_t count, Function&& function) {
                 return;
         }
 
-        // Always run the first chunk inline so the calling thread performs
-        // useful work while waiting on permits for the remaining chunks.
         const size_t chunk_size = (count + workers - 1) / workers;
+
+        // Each worker acquires its own shared permit from inside the async
+        // task, so the process-wide budget bounds concurrently *running*
+        // chunks. The calling thread only waits on futures and never holds a
+        // permit, which avoids a hold-and-wait deadlock between concurrent
+        // callers; excess chunks simply run as earlier workers free permits.
         std::vector<std::future<void>> futures;
-        futures.reserve(workers - 1);
-        for (size_t start = chunk_size; start < count; start += chunk_size) {
+        futures.reserve(workers);
+        for (size_t start = 0; start < count; start += chunk_size) {
                 const size_t end = std::min(start + chunk_size, count);
-                // Bound applies process-wide: each async chunk must hold a
-                // shared permit before spawning its worker thread.
-                ParallelPermitPool::Permit permit(parallelPermitPool());
-                futures.emplace_back(std::async(
-                    std::launch::async, [&function, start, end,
-                                         permit = std::move(permit)]() mutable {
+                futures.emplace_back(
+                    std::async(std::launch::async, [&function, start, end]() {
+                            ParallelPermitPool::Permit permit(
+                                parallelPermitPool());
                             for (size_t index = start; index < end; ++index) {
                                     function(index);
                             }
                     }));
-        }
-        const size_t first_end = std::min(chunk_size, count);
-        for (size_t index = 0; index < first_end; ++index) {
-                function(index);
         }
         for (auto& future : futures) {
                 future.get();

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -208,6 +208,17 @@ class TestMaskApi(unittest.TestCase):
         with self.assertRaises(ValueError):
             _mask.area(rles)
 
+    def test_parallel_batch_decode_multiple_malformed_items(self):
+        """Multiple malformed items must still surface an error deterministically."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+        # Two undersized items in different chunks of a parallel batch.
+        rles[1] = {"size": [32, 32], "counts": b"0"}
+        rles[9] = {"size": [32, 32], "counts": b"0"}
+
+        with self.assertRaises(ValueError):
+            _mask.decode(rles)
+
     def test_decode_rejects_count_larger_than_each_mask(self):
         """Reject oversized uncompressed RLE counts at construction time."""
         with self.assertRaises(ValueError):

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -209,7 +209,8 @@ class TestMaskApi(unittest.TestCase):
             _mask.area(rles)
 
     def test_parallel_batch_decode_multiple_malformed_items(self):
-        """Multiple malformed items must still surface an error deterministically."""
+        """Multiple malformed items must still surface an error
+        deterministically."""
         masks = self._parallel_batch_masks()
         rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
         # Two undersized items in different chunks of a parallel batch.

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -179,9 +179,7 @@ class TestMaskApi(unittest.TestCase):
         decoded = _mask.decode(eroded)
 
         for index, mask in enumerate(masks):
-            np.testing.assert_array_equal(
-                decoded[:, :, index], self._erode_reference(mask, 1)
-            )
+            np.testing.assert_array_equal(decoded[:, :, index], self._erode_reference(mask, 1))
 
     def test_parallel_batch_decode_propagates_malformed_item(self):
         """A malformed item in a parallel batch must surface its error."""

--- a/tests/test_mask_api.py
+++ b/tests/test_mask_api.py
@@ -117,6 +117,99 @@ class TestMaskApi(unittest.TestCase):
     def test_rles(self):
         self.assertTrue(np.all([_mask.encode(_mask.decode([rle])) == [rle] for rle in self.rleObjs]))
 
+    @staticmethod
+    def _parallel_batch_masks(count=16, shape=(32, 32), seed=7):
+        """Deterministic masks sized to cross the parallel batch threshold."""
+        rng = np.random.RandomState(seed)
+        masks = []
+        for i in range(count):
+            mask = np.zeros(shape, dtype=np.uint8)
+            mask[4 + i : 4 + i + 8, 3 + i : 3 + i + 9] = 1
+            mask[rng.rand(*shape) < 0.1] ^= 1
+            masks.append(mask)
+        return masks
+
+    @staticmethod
+    def _erode_reference(mask, dilation):
+        """Dense reference for 3x3-style erosion used by the parallel path."""
+        h, w = mask.shape
+        padded = np.pad(mask, dilation, mode="constant")
+        eroded = np.ones_like(mask)
+        for dy in range(2 * dilation + 1):
+            for dx in range(2 * dilation + 1):
+                eroded &= padded[dy : dy + h, dx : dx + w]
+        return eroded
+
+    def test_parallel_batch_encode_parity_and_order(self):
+        """Batch encode must match per-mask encode and keep slot order."""
+        masks = self._parallel_batch_masks()
+        stacked = np.asfortranarray(np.stack(masks, axis=2))
+
+        batch = _mask.encode(stacked)
+        solo = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+
+        self.assertEqual(batch, solo)
+
+    def test_parallel_batch_decode_parity_and_order(self):
+        """Batch decode must match per-mask decode and keep slot order."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+
+        decoded = _mask.decode(rles)
+
+        self.assertEqual(decoded.shape, (32, 32, len(masks)))
+        for index, mask in enumerate(masks):
+            np.testing.assert_array_equal(decoded[:, :, index], mask)
+
+    def test_parallel_batch_area_parity_and_order(self):
+        """Batch area must match per-mask areas in order."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+
+        areas = _mask.area(rles)
+
+        self.assertEqual(areas.tolist(), [int(m.sum()) for m in masks])
+
+    def test_parallel_batch_erode_parity_and_order(self):
+        """Batch erosion must match the dense reference and keep slot order."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+
+        eroded = _mask.erode_3x3(rles, 1)
+        decoded = _mask.decode(eroded)
+
+        for index, mask in enumerate(masks):
+            np.testing.assert_array_equal(
+                decoded[:, :, index], self._erode_reference(mask, 1)
+            )
+
+    def test_parallel_batch_decode_propagates_malformed_item(self):
+        """A malformed item in a parallel batch must surface its error."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+        rles[5] = {"size": [32, 32], "counts": b"0"}  # runs sum below h*w
+
+        with self.assertRaises(ValueError):
+            _mask.decode(rles)
+
+    def test_parallel_batch_erode_propagates_malformed_item(self):
+        """A malformed item must fail erode_3x3 even in a parallel batch."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+        rles[3] = {"size": [2, 2], "counts": b"05"}  # runs exceed h*w
+
+        with self.assertRaises(ValueError):
+            _mask.erode_3x3(rles, 1)
+
+    def test_parallel_batch_area_propagates_malformed_item(self):
+        """A malformed item must fail area even in a parallel batch."""
+        masks = self._parallel_batch_masks()
+        rles = [mask_util.encode(np.asfortranarray(m[..., None]))[0] for m in masks]
+        rles[2] = {"size": [2, 2], "counts": b"05"}  # runs exceed h*w
+
+        with self.assertRaises(ValueError):
+            _mask.area(rles)
+
     def test_decode_rejects_count_larger_than_each_mask(self):
         """Reject oversized uncompressed RLE counts at construction time."""
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Changes:
- Parallelize eligible batch encode, decode, erosion, and area work with bounded async tasks while preserving ordered result slots.
- Release the Python GIL around native batch work and keep batches below eight serial.

Impact:
- Improve 64-mask encode by 2.80x, decode by 1.43x, and erosion by 2.42x with exact output parity; area improves 1.03x.
- Avoid a TBB dependency and remove the unused parallel execution header.

Verification:
- python setup.py build_ext --inplace
- Full pytest: 146 passed, 2 skipped.
- Focused mask/basic/boundary tests: 46 passed.
- pre-commit run --all-files; shared lint, format, test, and review gates passed.
- Six order-balanced benchmark rounds matched exact output digests.

Residual limits:
- Throughput was measured on one macOS arm64 host with clang 21; area gain is marginal and cross-platform throughput is unmeasured.

---

part of #80