### PR TITLE
fix: add compatibility fallback for old pybind11 versions (closes #80)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,17 @@ import glob
 from importlib.util import module_from_spec, spec_from_file_location
 
 import setuptools
-from pybind11.setup_helpers import MACOS, WIN, ParallelCompile, Pybind11Extension, build_ext
+from pybind11.setup_helpers import MACOS, WIN, Pybind11Extension, build_ext
+
+try:
+    from pybind11.setup_helpers import ParallelCompile
+except ImportError:
+    # Fallback for older pybind11 versions (<2.6)
+    class ParallelCompile:
+        def __init__(self, *args, **kwargs):
+            pass
+        def install(self):
+            pass
 from setuptools import setup
 
 ParallelCompile("4").install()


### PR DESCRIPTION
## What
Older pybind11 versions (pre-2.6) do not export `ParallelCompile` from `setup_helpers`, causing an `ImportError` when building from source on systems with outdated pybind11.

## Fix
Add a fallback import that creates a no-op `ParallelCompile` class if the real one is unavailable. This preserves parallel build capability on modern pybind11 and allows builds on older versions without breaking.

Closes #80