### PR TITLE
perf(coco): parallelize category-area accumulation

### DIFF
--- a/csrc/faster_eval_api/coco_eval/cocoeval.cpp
+++ b/csrc/faster_eval_api/coco_eval/cocoeval.cpp
@@ -598,95 +598,123 @@ py::dict Accumulate(const py::object& params,
                 num_area_ranges * num_max_detections,
             -1);
 
-        // Consider the list of all detected instances in the entire dataset in
-        // one large list.  evaluation_indices, detection_scores,
-        // image_detection_indices, and detection_sorted_indices all have the
-        // same length as this list, such that each entry corresponds to one
-        // detected instance
-        std::vector<uint64_t> evaluation_indices;  // indices into evaluations[]
-        std::vector<double>
-            detection_scores;  // detection scores of each instance
-        std::vector<uint64_t>
-            detection_sorted_indices;  // sorted indices of all
-                                       // instances in the dataset
-        std::vector<uint64_t>
-            image_detection_indices;  // indices into the list of detected
-                                      // instances in the same image as each
-                                      // instance
-        std::vector<double> precisions, recalls;
+        const std::size_t task_count =
+            static_cast<std::size_t>(num_categories * num_area_ranges);
+        const std::size_t worker_count = std::min<std::size_t>(
+            task_count, std::max(1u, std::thread::hardware_concurrency()));
 
-        for (auto c = 0; c < num_categories; ++c) {
-                for (auto a = 0; a < num_area_ranges; ++a) {
-                        for (auto m = 0; m < num_max_detections; ++m) {
-                                // The COCO PythonAPI assumes evaluations[] (the
-                                // return value of COCOeval::EvaluateImages() is
-                                // one long list storing results for each
-                                // combination of category, area range, and
-                                // image id, with categories in the outermost
-                                // loop and images in the innermost loop.
-                                const int64_t evaluations_index =
-                                    c * num_area_ranges * num_images +
-                                    a * num_images;
-                                int num_valid_ground_truth =
-                                    BuildSortedDetectionList(
-                                        evaluations, evaluations_index,
-                                        num_images, max_detections[m],
-                                        &evaluation_indices, &detection_scores,
-                                        &detection_sorted_indices,
-                                        &image_detection_indices);
+        auto accumulate_category_area = [&](const std::size_t task_index) {
+                const auto c = static_cast<int>(task_index / num_area_ranges);
+                const auto a = static_cast<int>(task_index % num_area_ranges);
+                const int64_t evaluations_index =
+                    c * num_area_ranges * num_images + a * num_images;
 
-                                if (num_valid_ground_truth == 0) {
-                                        continue;
+                // Every task owns these temporary buffers and disjoint output
+                // slices, so workers cannot race on evaluator state.
+                std::vector<uint64_t> evaluation_indices;
+                std::vector<double> detection_scores;
+                std::vector<uint64_t> detection_sorted_indices;
+                std::vector<uint64_t> image_detection_indices;
+                std::vector<double> precisions, recalls;
+
+                for (auto m = 0; m < num_max_detections; ++m) {
+                        const int num_valid_ground_truth =
+                            BuildSortedDetectionList(
+                                evaluations, evaluations_index, num_images,
+                                max_detections[m], &evaluation_indices,
+                                &detection_scores, &detection_sorted_indices,
+                                &image_detection_indices);
+
+                        if (num_valid_ground_truth == 0) {
+                                continue;
+                        }
+
+                        for (auto t = 0; t < num_iou_thresholds; ++t) {
+                                // recalls_out is a flattened vectors
+                                // representing a num_iou_thresholds X
+                                // num_categories X num_area_ranges X
+                                // num_max_detections matrix
+                                const int64_t recalls_out_index =
+                                    t * num_categories * num_area_ranges *
+                                        num_max_detections +
+                                    c * num_area_ranges * num_max_detections +
+                                    a * num_max_detections + m;
+
+                                // precisions_out and scores_out are
+                                // flattened vectors representing a
+                                // num_iou_thresholds X
+                                // num_recall_thresholds X
+                                // num_categories X num_area_ranges X
+                                // num_max_detections matrix
+                                const int64_t precisions_out_stride =
+                                    num_categories * num_area_ranges *
+                                    num_max_detections;
+                                const int64_t precisions_out_index =
+                                    t * num_recall_thresholds * num_categories *
+                                        num_area_ranges * num_max_detections +
+                                    c * num_area_ranges * num_max_detections +
+                                    a * num_max_detections + m;
+
+                                ComputePrecisionRecallCurve(
+                                    precisions_out_index, precisions_out_stride,
+                                    recalls_out_index, recall_thresholds, t,
+                                    num_iou_thresholds, num_valid_ground_truth,
+                                    evaluations, evaluation_indices,
+                                    detection_scores, detection_sorted_indices,
+                                    image_detection_indices, &precisions,
+                                    &recalls, &precisions_out, &scores_out,
+                                    &recalls_out);
+                        }
+                }
+        };
+
+        std::exception_ptr first_exception;
+        {
+                py::gil_scoped_release release;
+                if (worker_count == 1) {
+                        try {
+                                for (std::size_t task_index = 0;
+                                     task_index < task_count; ++task_index) {
+                                        accumulate_category_area(task_index);
                                 }
+                        } catch (...) {
+                                first_exception = std::current_exception();
+                        }
+                } else {
+                        std::atomic<std::size_t> next_task{0};
+                        auto accumulate_tasks = [&]() {
+                                while (true) {
+                                        const std::size_t task_index =
+                                            next_task.fetch_add(1);
+                                        if (task_index >= task_count) {
+                                                return;
+                                        }
+                                        accumulate_category_area(task_index);
+                                }
+                        };
 
-                                for (auto t = 0; t < num_iou_thresholds; ++t) {
-                                        // recalls_out is a flattened vectors
-                                        // representing a num_iou_thresholds X
-                                        // num_categories X num_area_ranges X
-                                        // num_max_detections matrix
-                                        const int64_t recalls_out_index =
-                                            t * num_categories *
-                                                num_area_ranges *
-                                                num_max_detections +
-                                            c * num_area_ranges *
-                                                num_max_detections +
-                                            a * num_max_detections + m;
+                        std::vector<std::future<void>> futures;
+                        futures.reserve(worker_count);
+                        for (std::size_t worker = 0; worker < worker_count;
+                             ++worker) {
+                                futures.emplace_back(std::async(
+                                    std::launch::async, accumulate_tasks));
+                        }
 
-                                        // precisions_out and scores_out are
-                                        // flattened vectors representing a
-                                        // num_iou_thresholds X
-                                        // num_recall_thresholds X
-                                        // num_categories X num_area_ranges X
-                                        // num_max_detections matrix
-                                        const int64_t precisions_out_stride =
-                                            num_categories * num_area_ranges *
-                                            num_max_detections;
-                                        const int64_t precisions_out_index =
-                                            t * num_recall_thresholds *
-                                                num_categories *
-                                                num_area_ranges *
-                                                num_max_detections +
-                                            c * num_area_ranges *
-                                                num_max_detections +
-                                            a * num_max_detections + m;
-
-                                        ComputePrecisionRecallCurve(
-                                            precisions_out_index,
-                                            precisions_out_stride,
-                                            recalls_out_index,
-                                            recall_thresholds, t,
-                                            num_iou_thresholds,
-                                            num_valid_ground_truth, evaluations,
-                                            evaluation_indices,
-                                            detection_scores,
-                                            detection_sorted_indices,
-                                            image_detection_indices,
-                                            &precisions, &recalls,
-                                            &precisions_out, &scores_out,
-                                            &recalls_out);
+                        for (auto& future : futures) {
+                                try {
+                                        future.get();
+                                } catch (...) {
+                                        if (!first_exception) {
+                                                first_exception =
+                                                    std::current_exception();
+                                        }
                                 }
                         }
                 }
+        }
+        if (first_exception) {
+                std::rethrow_exception(first_exception);
         }
 
         time_t rawtime;

--- a/tests/test_coco_api_and_evaluator_regressions.py
+++ b/tests/test_coco_api_and_evaluator_regressions.py
@@ -118,6 +118,25 @@ def test_math_matches_clears_annotations_before_a_second_run():
     assert evaluator.cocoGt.anns[1]["fn"] is True
 
 
+def test_accumulation_is_deterministic_across_category_area_tasks():
+    """Repeated native accumulation must preserve every result tensor."""
+    evaluator = _make_eval(include_second_pair=True)
+
+    evaluator.evaluate()
+    evaluator.accumulate()
+    first_result = {key: np.array(evaluator.eval[key], copy=True) for key in ("precision", "recall", "scores")}
+    first_counts = list(evaluator.eval["counts"])
+    first_matches = dict(evaluator.eval["matched"])
+
+    evaluator.evaluate()
+    evaluator.accumulate()
+
+    for key, expected in first_result.items():
+        np.testing.assert_array_equal(evaluator.eval[key], expected)
+    assert evaluator.eval["counts"] == first_counts
+    assert evaluator.eval["matched"] == first_matches
+
+
 def test_evaluate_rle_iou_worker_cap_two_overlaps_real_iou_results(monkeypatch: pytest.MonkeyPatch):
     """Two RLE IoUs should overlap and retain the serial evaluator's values."""
     expected_concurrent_pairs = 2


### PR DESCRIPTION
## Summary

Run independent category×area Accumulate slices with a bounded C++17 worker set. Each worker owns scratch vectors and writes only disjoint output slices; matched-annotation aggregation remains serial and deterministic.

## Why

The category×area loop is CPU-bound and serial despite independent precision, score, and recall output regions.

## Benchmark

Full COCO-shaped Accumulate workload, stacked on score-sort reuse:

| Metric     |     Serial |   Parallel |               Result |
| ---------- | ---------: | ---------: | -------------------: |
| Accumulate | 1.027229 s | 0.588954 s | 1.7442x, 42.67% less |

Small controls did not regress: 1×1, 0.00214 → 0.00197 s; 100×1, 0.00436 → 0.00428 s. Precision, scores, recall, counts, shapes, and sorted matches had identical digests. The branch-local 1,000-image metric also reduced Accumulate median from the preceding serial/sort run's 0.269 s to 0.117 s; this is context only, not a controlled standalone comparison.

## Compatibility

- No Python API, public worker setting, or dependency change.
- Uses existing C++17 facilities; no OpenMP, TBB, or runtime library.
- Rethrows worker exceptions after GIL reacquisition.

## Verification

- Rebuilt native extensions with Python 3.10.
- Focused evaluator suite: 50 passed.
- New repeated-evaluation test verifies exact precision, recall, scores, counts, and matched-map stability.
- Exact bbox pycocotools parity: `rtol=atol=1e-10`.

## Rollout / risk

Merge after #121 `perf/sort-reuse`; the branches intentionally share no commits but both edit native Accumulate. Before release, run Linux ASan/TSan coverage and 1/2/4/8-rank DDP oversubscription measurements. Do not ship an unbounded pool or add a public worker knob unless those gates prove it necessary.
