### PR TITLE
perf(coco): skip empty IoU pair calculations

### DIFF
--- a/faster_coco_eval/core/cocoeval.py
+++ b/faster_coco_eval/core/cocoeval.py
@@ -158,6 +158,8 @@ class COCOeval:
             self.freq_groups = self._prepare_freq_group()
 
         img_sizes = defaultdict(tuple)
+        gt_pairs: set[tuple[int, int]] = set()
+        dt_pairs: set[tuple[int, int]] = set()
 
         def get_img_size_by_id(image_id: int, dataset: COCO) -> tuple:
             """Get image size by image id.
@@ -188,6 +190,7 @@ class COCOeval:
 
         for gt in gts:
             self.gt_dataset.append_ref(gt["image_id"], gt["category_id"], gt)
+            gt_pairs.add((gt["image_id"], gt["category_id"]))
 
         for dt in dts:
             img_id, cat_id = dt["image_id"], dt["category_id"]
@@ -213,6 +216,14 @@ class COCOeval:
         for dt in dts:
             if not dt.get("drop", False):
                 self.dt_dataset.append_ref(dt["image_id"], dt["category_id"], dt)
+                dt_pairs.add((dt["image_id"], dt["category_id"]))
+
+        if p.useCats:
+            self._nonempty_iou_pairs = gt_pairs & dt_pairs
+        else:
+            gt_image_ids = {image_id for image_id, _ in gt_pairs}
+            dt_image_ids = {image_id for image_id, _ in dt_pairs}
+            self._nonempty_iou_pairs = {(image_id, -1) for image_id in gt_image_ids & dt_image_ids}
 
     def _prepare_freq_group(self) -> list:
         """Prepare frequency group for LVIS evaluation.

--- a/faster_coco_eval/core/faster_eval_api.py
+++ b/faster_coco_eval/core/faster_eval_api.py
@@ -81,7 +81,16 @@ class COCOeval_faster(COCOevalBase):
         else:
             raise ValueError(f"p.iouType must be segm, bbox, boundary or keypoints. Get {p.iouType}")
 
-        pair_count = len(p.imgIds) * len(catIds)
+        all_iou_pairs = list(itertools.product(p.imgIds, catIds))
+        nonempty_iou_pairs = getattr(self, "_nonempty_iou_pairs", None)
+        pairs_to_compute = (
+            all_iou_pairs
+            if nonempty_iou_pairs is None
+            else [pair for pair in all_iou_pairs if pair in nonempty_iou_pairs]
+        )
+        self.ious = {pair: [] for pair in all_iou_pairs}
+
+        pair_count = len(pairs_to_compute)
         max_workers = 1
         if p.compute_rle and self.rle_iou_max_workers > 1 and pair_count > 1:
             max_workers = min(_available_cpu_count(), self.rle_iou_max_workers, pair_count)
@@ -90,7 +99,7 @@ class COCOeval_faster(COCOevalBase):
             # order preserves deterministic dictionary layout while the bounded
             # queue prevents one future per image/category pair.
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                iou_pairs = iter(itertools.product(p.imgIds, catIds))
+                iou_pairs = iter(pairs_to_compute)
                 pending_ious = deque()
                 for _ in range(2 * max_workers):
                     try:
@@ -99,18 +108,17 @@ class COCOeval_faster(COCOevalBase):
                         break
                     pending_ious.append((pair, executor.submit(computeIoU, *pair)))
 
-                computed_ious = {}
                 while pending_ious:
                     pair, future = pending_ious.popleft()
-                    computed_ious[pair] = future.result()
+                    self.ious[pair] = future.result()
                     try:
                         next_pair = next(iou_pairs)
                     except StopIteration:
                         continue
                     pending_ious.append((next_pair, executor.submit(computeIoU, *next_pair)))
-                self.ious = computed_ious
         else:
-            self.ious = {pair: computeIoU(*pair) for pair in itertools.product(p.imgIds, catIds)}
+            for pair in pairs_to_compute:
+                self.ious[pair] = computeIoU(*pair)
 
         # Memory optimization: pass datasets directly instead of pre-loading all instances
 

--- a/tests/test_coco_api_and_evaluator_regressions.py
+++ b/tests/test_coco_api_and_evaluator_regressions.py
@@ -180,6 +180,7 @@ def test_sparse_iou_dispatch_preserves_empty_public_pairs(
     assert evaluator.iou_calls == expected_calls
     assert evaluator.ious[(2, 1 if use_categories else -1)] == []
 
+
 def test_accumulation_is_deterministic_across_category_area_tasks():
     """Repeated native accumulation must preserve every result tensor."""
     evaluator = _make_eval(include_second_pair=True)

--- a/tests/test_coco_api_and_evaluator_regressions.py
+++ b/tests/test_coco_api_and_evaluator_regressions.py
@@ -118,6 +118,69 @@ def test_math_matches_clears_annotations_before_a_second_run():
     assert evaluator.cocoGt.anns[1]["fn"] is True
 
 
+@pytest.mark.parametrize(
+    ("use_categories", "expected_keys", "expected_calls"),
+    [
+        pytest.param(
+            True,
+            {(1, 1), (1, 2), (2, 1), (2, 2)},
+            [(1, 1)],
+            id="category-aware",
+        ),
+        pytest.param(
+            False,
+            {(1, -1), (2, -1)},
+            [(1, -1)],
+            id="merged-categories",
+        ),
+    ],
+)
+def test_sparse_iou_dispatch_preserves_empty_public_pairs(
+    use_categories: bool,
+    expected_keys: set[tuple[int, int]],
+    expected_calls: list[tuple[int, int]],
+):
+    """Only GT/DT intersections compute IoU while public keys stay complete."""
+
+    class CountingEvaluator(COCOeval_faster):
+        """Record IoU calls while retaining the evaluator implementation."""
+
+        def __init__(self, coco_gt: COCO, coco_dt: COCO):
+            """Initialize the evaluator and its observed call list."""
+            super().__init__(coco_gt, coco_dt, iouType="bbox", print_function=lambda *_: None)
+            self.iou_calls: list[tuple[int, int]] = []
+
+        def computeIoU(self, imgId: int, catId: int) -> list[float] | np.ndarray:
+            """Record the pair before running the real bbox calculation."""
+            self.iou_calls.append((imgId, catId))
+            return super().computeIoU(imgId, catId)
+
+    coco_gt = COCO()
+    coco_gt.dataset = {
+        "images": [
+            {"id": 1, "width": 20, "height": 20},
+            {"id": 2, "width": 20, "height": 20},
+        ],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0, 0, 10, 10], "area": 100},
+            {"id": 2, "image_id": 2, "category_id": 1, "bbox": [0, 0, 10, 10], "area": 100},
+        ],
+        "categories": [{"id": 1, "name": "one"}, {"id": 2, "name": "two"}],
+    }
+    coco_gt.createIndex()
+    coco_dt = coco_gt.loadRes([
+        {"image_id": 1, "category_id": 1, "bbox": [0, 0, 10, 10], "score": 1.0},
+        {"image_id": 1, "category_id": 2, "bbox": [0, 0, 10, 10], "score": 0.5},
+    ])
+    evaluator = CountingEvaluator(coco_gt, coco_dt)
+    evaluator.params.useCats = int(use_categories)
+    evaluator.evaluate()
+
+    assert set(evaluator.ious) == expected_keys
+    assert evaluator.iou_calls == expected_calls
+    assert evaluator.ious[(2, 1 if use_categories else -1)] == []
+
+
 def test_evaluate_rle_iou_worker_cap_two_overlaps_real_iou_results(monkeypatch: pytest.MonkeyPatch):
     """Two RLE IoUs should overlap and retain the serial evaluator's values."""
     expected_concurrent_pairs = 2


### PR DESCRIPTION
## Summary

Record non-empty GT and detection pairs during preparation, then compute IoU or OKS only for their intersection. `self.ious` remains a complete image×category mapping; skipped pairs retain `[]` exactly as before.

## Why

COCO bbox evaluation visited every 5,000×80 image/category pair even when GT or detections were empty. Empty sides cannot produce IoU or OKS values.

## Benchmark

COCO2017-shaped direct bbox fused evaluation:

| Metric               |   Baseline | Sparse dispatch |              Result |
| -------------------- | ---------: | --------------: | ------------------: |
| Full fused evaluator | 4.384465 s |      4.160287 s | 1.0539x, 5.11% less |

The full correctness digest was identical. The branch-local 1,000-image run also produced one exact digest over three repeats; its absolute timing is not used as a baseline comparison.

## Compatibility

- No public Python signature, default, result type, or dependency change.
- Preserves the full observable `self.ious` key set and empty values.
- Covers category-aware evaluation, `useCats=False`, and post-LVIS-drop DT filtering.

## Verification

- Focused evaluator suite: 51 passed.
- New regression covers GT-only, DT-only, category-aware, and merged-category dispatch.
- Exact bbox pycocotools parity: `rtol=atol=1e-10`.

## Rollout

Can merge independently of the native changes. Before claiming segmentation or keypoint speedup, run their exact parity and integrated benchmark: sparse dispatch applies before RLE IoU and OKS, but their relative cost differs from bbox.
