### PR TITLE
perf(coco): remove two per-annotation bottlenecks from `_prepare`

### DIFF
--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -23,6 +23,61 @@ void LightweightDataset::append_ref(double img_id, double cat_id,
         annotation_refs[key].emplace_back(ann_ref);
 }
 
+// Store a whole annotation sequence in one call.
+//
+// The per-annotation append_ref binding costs roughly 287ns of pybind dispatch
+// per call, which dominates ingest for detection-sized inputs. Looping here
+// instead pays that cost once. The returned set of (image_id, category_id)
+// tuples is what the caller would otherwise rebuild in a second Python loop.
+py::set LightweightDataset::append_batch(const py::sequence& annotations,
+                                         bool skip_dropped) {
+        py::set pairs;
+
+        const py::str image_key("image_id");
+        const py::str category_key("category_id");
+        const py::str drop_key("drop");
+
+        for (const py::handle& item : annotations) {
+                const py::dict ann = py::reinterpret_borrow<py::dict>(item);
+
+                if (skip_dropped) {
+                        // Mirror Python's ``not ann.get("drop", False)``:
+                        // truthiness, not a bool cast. Annotations come from
+                        // user data, so "drop" may hold any object; casting
+                        // would raise where the original loop simply evaluated
+                        // it.
+                        const py::object drop_obj =
+                            ann.contains(drop_key)
+                                ? py::reinterpret_borrow<py::object>(
+                                      ann[drop_key])
+                                : py::none();
+                        const int is_true = PyObject_IsTrue(drop_obj.ptr());
+                        if (is_true == -1) {
+                                throw py::error_already_set();
+                        }
+                        if (is_true == 1) {
+                                continue;
+                        }
+                }
+
+                const py::object img_obj = ann[image_key];
+                const py::object cat_obj = ann[category_key];
+
+                const std::pair<int64_t, int64_t> key{
+                    static_cast<int64_t>(img_obj.cast<double>()),
+                    static_cast<int64_t>(cat_obj.cast<double>())};
+                annotation_refs[key].emplace_back(
+                    py::reinterpret_borrow<py::object>(item));
+
+                // Carry the original id objects, not the narrowed int64 copies,
+                // so the caller's pair set stays identical to the Python
+                // loop's.
+                pairs.add(py::make_tuple(img_obj, cat_obj));
+        }
+
+        return pairs;
+}
+
 // Remove all stored references and clear cache
 void LightweightDataset::clean() {
         annotation_refs.clear();

--- a/csrc/faster_eval_api/coco_eval/dataset.h
+++ b/csrc/faster_eval_api/coco_eval/dataset.h
@@ -38,6 +38,12 @@ class LightweightDataset {
         // Store reference to annotation instead of copying data
         void append_ref(double img_id, double cat_id, py::object ann_ref);
 
+        // Store a whole annotation sequence in one call, returning the set of
+        // (image_id, category_id) tuples encountered. Set skip_dropped to skip
+        // annotations carrying a truthy "drop" key.
+        py::set append_batch(const py::sequence& annotations,
+                             bool skip_dropped);
+
         // Remove all stored references and clear cache
         void clean();
 

--- a/csrc/faster_eval_api/faster_eval_api.cpp
+++ b/csrc/faster_eval_api/faster_eval_api.cpp
@@ -102,6 +102,9 @@ PYBIND11_MODULE(faster_eval_api_cpp, m) {
         pybind11::class_<COCOeval::LightweightDataset>(m, "Dataset")
             .def(pybind11::init<>())
             .def("append_ref", &COCOeval::LightweightDataset::append_ref)
+            .def("append_batch", &COCOeval::LightweightDataset::append_batch,
+                 pybind11::arg("annotations"),
+                 pybind11::arg("skip_dropped") = false)
             .def("append",
                  &COCOeval::LightweightDataset::append)  // Legacy compatibility
             .def("clean", &COCOeval::LightweightDataset::clean)

--- a/faster_coco_eval/core/coco.py
+++ b/faster_coco_eval/core/coco.py
@@ -242,6 +242,52 @@ class COCO:
         ids = list(map(lambda ann: ann["id"], anns))
         return ids
 
+    def getAnns(
+        self,
+        imgIds: list[int] | None = None,
+        catIds: list[int] | None = None,
+    ) -> list[dict]:
+        """Get annotation objects directly, without a round trip through ids.
+
+        ``loadAnns(getAnnIds(...))`` collects these same dicts, maps them to
+        ids, validates every id, then looks each one back up. For evaluation
+        sized workloads that round trip costs more than the lookup it performs,
+        so this returns the objects the index already holds.
+
+        Selection matches :meth:`getAnnIds` for the same arguments, including
+        its image iteration order, so callers observe the same annotation
+        sequence.
+
+        Args:
+            imgIds (List[int], optional): Get anns for given images. Defaults to None.
+            catIds (List[int], optional): Get anns for given categories. Defaults to None.
+
+        Returns:
+            List[dict]: Annotation objects satisfying the criteria.
+
+        Examples:
+            >>> coco = COCO()
+            >>> coco.getAnns(imgIds=[], catIds=[])
+            []
+        """
+        imgIds = [] if imgIds is None else imgIds
+        catIds = [] if catIds is None else catIds
+        imgIds = set(imgIds if _isArrayLike(imgIds) else [imgIds])
+        catIds = set(catIds if _isArrayLike(catIds) else [catIds])
+
+        if not imgIds:
+            anns = self.dataset["annotations"]
+        else:
+            anns = []
+            for img_id in imgIds:
+                # ``.get`` rather than ``img_ann_map[...]`` so that querying an
+                # unknown image id does not grow the underlying defaultdict.
+                anns.extend(self.img_ann_map.get(img_id, ()))
+
+        if catIds:
+            return [ann for ann in anns if ann["category_id"] in catIds]
+        return list(anns)
+
     def getCatIds(
         self,
         catNms: list[str] | None = None,

--- a/faster_coco_eval/core/cocoeval.py
+++ b/faster_coco_eval/core/cocoeval.py
@@ -137,8 +137,10 @@ class COCOeval:
 
         cat_ids = p.catIds if p.catIds else None
 
-        gts = self.cocoGt.loadAnns(self.cocoGt.getAnnIds(imgIds=p.imgIds, catIds=cat_ids))
-        dts = self.cocoDt.loadAnns(self.cocoDt.getAnnIds(imgIds=p.imgIds, catIds=cat_ids))
+        # getAnns avoids the annotation -> id -> annotation round trip that
+        # loadAnns(getAnnIds(...)) performs; selection and order are identical.
+        gts = self.cocoGt.getAnns(imgIds=p.imgIds, catIds=cat_ids)
+        dts = self.cocoDt.getAnns(imgIds=p.imgIds, catIds=cat_ids)
 
         # pycocotools gives iscrowd precedence over a dataset-provided ignore flag.
         for gt in gts:

--- a/faster_coco_eval/core/cocoeval.py
+++ b/faster_coco_eval/core/cocoeval.py
@@ -160,8 +160,6 @@ class COCOeval:
             self.freq_groups = self._prepare_freq_group()
 
         img_sizes = defaultdict(tuple)
-        gt_pairs: set[tuple[int, int]] = set()
-        dt_pairs: set[tuple[int, int]] = set()
 
         def get_img_size_by_id(image_id: int, dataset: COCO) -> tuple:
             """Get image size by image id.
@@ -190,9 +188,9 @@ class COCOeval:
             self.boundary_cpu_count,
         )
 
-        for gt in gts:
-            self.gt_dataset.append_ref(gt["image_id"], gt["category_id"], gt)
-            gt_pairs.add((gt["image_id"], gt["category_id"]))
+        # One native call instead of one per annotation; the returned set is the
+        # (image_id, category_id) pairs the per-annotation loop used to collect.
+        gt_pairs = self.gt_dataset.append_batch(gts, False)
 
         for dt in dts:
             img_id, cat_id = dt["image_id"], dt["category_id"]
@@ -215,10 +213,7 @@ class COCOeval:
             self.boundary_cpu_count,
         )
 
-        for dt in dts:
-            if not dt.get("drop", False):
-                self.dt_dataset.append_ref(dt["image_id"], dt["category_id"], dt)
-                dt_pairs.add((dt["image_id"], dt["category_id"]))
+        dt_pairs = self.dt_dataset.append_batch(dts, True)
 
         if p.useCats:
             self._nonempty_iou_pairs = gt_pairs & dt_pairs

--- a/tests/test_coco_api_and_evaluator_regressions.py
+++ b/tests/test_coco_api_and_evaluator_regressions.py
@@ -625,3 +625,78 @@ class TestGetAnns:
 
         assert coco.getAnns(imgIds=[999], catIds=[1]) == []
         assert set(coco.img_ann_map) == before
+
+
+class TestDatasetAppendBatch:
+    """Batched annotation ingress used by COCOeval._prepare."""
+
+    @staticmethod
+    def _ann(drop=..., image_id: int = 1, category_id: int = 1) -> dict:
+        """One annotation, optionally carrying a ``drop`` marker."""
+        ann = {"image_id": image_id, "category_id": category_id, "id": 1}
+        if drop is not ...:
+            ann["drop"] = drop
+        return ann
+
+    @pytest.mark.parametrize(
+        "drop",
+        [
+            pytest.param(..., id="key-absent"),
+            pytest.param(False, id="false"),
+            pytest.param(True, id="true"),
+            pytest.param(0, id="int-zero"),
+            pytest.param(1, id="int-one"),
+            pytest.param(None, id="none"),
+            pytest.param("", id="empty-string"),
+            pytest.param("yes", id="non-empty-string"),
+            pytest.param([], id="empty-list"),
+            pytest.param([0], id="non-empty-list"),
+        ],
+    )
+    def test_skip_dropped_follows_python_truthiness(self, drop):
+        """A dropped annotation is decided by truthiness, not a bool cast.
+
+        _prepare replaced `if not dt.get("drop", False)` with this native call.
+        Annotations come from user-supplied data, so "drop" can hold any object;
+        a bool cast raises on a string where the original loop just evaluated
+        it, silently turning valid input into a crash.
+        """
+        from faster_coco_eval.faster_eval_api_cpp import Dataset
+
+        ann = self._ann(drop)
+        expected_kept = not ann.get("drop", False)
+
+        dataset = Dataset()
+        dataset.append_batch([ann], True)
+
+        assert (len(dataset) > 0) == expected_kept
+
+    def test_returns_encountered_image_category_pairs(self):
+        """The returned set replaces the caller's own pair-collecting loop.
+
+        _prepare intersects the ground-truth and detection pair sets to decide
+        which IoU pairs are non-empty, so a wrong set silently changes which
+        image/category combinations get evaluated at all.
+        """
+        from faster_coco_eval.faster_eval_api_cpp import Dataset
+
+        anns = [self._ann(image_id=1, category_id=1), self._ann(image_id=2, category_id=3)]
+
+        pairs = Dataset().append_batch(anns, False)
+
+        assert pairs == {(1, 1), (2, 3)}
+
+    def test_dropped_annotations_are_absent_from_returned_pairs(self):
+        """A dropped annotation contributes neither storage nor a pair.
+
+        If a dropped detection still registered its pair, _prepare would treat
+        that image/category as non-empty and evaluate a bucket with no
+        detections in it.
+        """
+        from faster_coco_eval.faster_eval_api_cpp import Dataset
+
+        anns = [self._ann(image_id=1, category_id=1), self._ann(True, image_id=2, category_id=3)]
+
+        pairs = Dataset().append_batch(anns, True)
+
+        assert pairs == {(1, 1)}

--- a/tests/test_coco_api_and_evaluator_regressions.py
+++ b/tests/test_coco_api_and_evaluator_regressions.py
@@ -589,11 +589,12 @@ class TestGetAnns:
         ],
     )
     def test_matches_load_anns_of_get_ann_ids(self, img_ids, cat_ids):
-        """getAnns returns exactly what loadAnns(getAnnIds(...)) returns.
+        """GetAnns returns exactly what loadAnns(getAnnIds(...)) returns.
 
-        _prepare swapped the id round trip for this call, so any divergence in
-        selection or ordering would silently change which detections land in
-        each image/category bucket and shift the evaluation result.
+        _prepare swapped the id round trip for this call, so any
+        divergence in selection or ordering would silently change which
+        detections land in each image/category bucket and shift the
+        evaluation result.
         """
         coco = self._dataset()
 
@@ -617,8 +618,9 @@ class TestGetAnns:
     def test_unknown_image_id_does_not_grow_the_index(self):
         """Querying a missing image id leaves img_ann_map untouched.
 
-        img_ann_map is a defaultdict, so a bare subscript would insert an empty
-        list for every unknown id and slowly leak entries across evaluations.
+        img_ann_map is a defaultdict, so a bare subscript would insert
+        an empty list for every unknown id and slowly leak entries
+        across evaluations.
         """
         coco = self._dataset()
         before = set(coco.img_ann_map)
@@ -656,10 +658,11 @@ class TestDatasetAppendBatch:
     def test_skip_dropped_follows_python_truthiness(self, drop):
         """A dropped annotation is decided by truthiness, not a bool cast.
 
-        _prepare replaced `if not dt.get("drop", False)` with this native call.
-        Annotations come from user-supplied data, so "drop" can hold any object;
-        a bool cast raises on a string where the original loop just evaluated
-        it, silently turning valid input into a crash.
+        _prepare replaced `if not dt.get("drop", False)` with this
+        native call. Annotations come from user-supplied data, so "drop"
+        can hold any object; a bool cast raises on a string where the
+        original loop just evaluated it, silently turning valid input
+        into a crash.
         """
         from faster_coco_eval.faster_eval_api_cpp import Dataset
 
@@ -674,9 +677,9 @@ class TestDatasetAppendBatch:
     def test_returns_encountered_image_category_pairs(self):
         """The returned set replaces the caller's own pair-collecting loop.
 
-        _prepare intersects the ground-truth and detection pair sets to decide
-        which IoU pairs are non-empty, so a wrong set silently changes which
-        image/category combinations get evaluated at all.
+        _prepare intersects the ground-truth and detection pair sets to
+        decide which IoU pairs are non-empty, so a wrong set silently
+        changes which image/category combinations get evaluated at all.
         """
         from faster_coco_eval.faster_eval_api_cpp import Dataset
 
@@ -689,9 +692,9 @@ class TestDatasetAppendBatch:
     def test_dropped_annotations_are_absent_from_returned_pairs(self):
         """A dropped annotation contributes neither storage nor a pair.
 
-        If a dropped detection still registered its pair, _prepare would treat
-        that image/category as non-empty and evaluate a bucket with no
-        detections in it.
+        If a dropped detection still registered its pair, _prepare would
+        treat that image/category as non-empty and evaluate a bucket
+        with no detections in it.
         """
         from faster_coco_eval.faster_eval_api_cpp import Dataset
 

--- a/tests/test_coco_api_and_evaluator_regressions.py
+++ b/tests/test_coco_api_and_evaluator_regressions.py
@@ -560,3 +560,68 @@ def test_custom_summary_layout_matches_configured_ranges_and_max_dets():
     assert list(evaluator.stats_as_dict) == expected_labels
     assert len(evaluator.all_stats) == len(expected_labels)
     assert len(evaluator.stats) == 3 + len(ranges) * 2 + len(evaluator.params.maxDets)
+
+
+class TestGetAnns:
+    """Direct annotation lookup used by COCOeval._prepare."""
+
+    @staticmethod
+    def _dataset() -> COCO:
+        """Two images, two categories, one annotation each combination."""
+        return COCO({
+            "images": [{"id": 1, "width": 20, "height": 20}, {"id": 2, "width": 20, "height": 20}],
+            "categories": [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}],
+            "annotations": [
+                {"id": 10, "image_id": 1, "category_id": 1, "bbox": [0, 0, 5, 5], "area": 25.0, "iscrowd": 0},
+                {"id": 11, "image_id": 1, "category_id": 2, "bbox": [1, 1, 5, 5], "area": 25.0, "iscrowd": 0},
+                {"id": 12, "image_id": 2, "category_id": 1, "bbox": [2, 2, 5, 5], "area": 25.0, "iscrowd": 0},
+            ],
+        })
+
+    @pytest.mark.parametrize(
+        ("img_ids", "cat_ids"),
+        [
+            pytest.param([1, 2], [1, 2], id="all-images-all-categories"),
+            pytest.param([1], [1, 2], id="one-image"),
+            pytest.param([1, 2], [1], id="one-category"),
+            pytest.param([], [], id="no-filter"),
+            pytest.param([2], [2], id="empty-intersection"),
+        ],
+    )
+    def test_matches_load_anns_of_get_ann_ids(self, img_ids, cat_ids):
+        """getAnns returns exactly what loadAnns(getAnnIds(...)) returns.
+
+        _prepare swapped the id round trip for this call, so any divergence in
+        selection or ordering would silently change which detections land in
+        each image/category bucket and shift the evaluation result.
+        """
+        coco = self._dataset()
+
+        direct = coco.getAnns(imgIds=img_ids, catIds=cat_ids)
+        via_ids = coco.loadAnns(coco.getAnnIds(imgIds=img_ids, catIds=cat_ids))
+
+        assert [ann["id"] for ann in direct] == [ann["id"] for ann in via_ids]
+
+    def test_returns_the_indexed_objects_not_copies(self):
+        """Returned dicts are the index's own objects.
+
+        _prepare mutates annotations in place (the ``ignore`` flag) and expects
+        those writes to be visible to the evaluator afterwards.
+        """
+        coco = self._dataset()
+
+        anns = coco.getAnns(imgIds=[1], catIds=[1])
+
+        assert anns[0] is coco.anns[10]
+
+    def test_unknown_image_id_does_not_grow_the_index(self):
+        """Querying a missing image id leaves img_ann_map untouched.
+
+        img_ann_map is a defaultdict, so a bare subscript would insert an empty
+        list for every unknown id and slowly leak entries across evaluations.
+        """
+        coco = self._dataset()
+        before = set(coco.img_ann_map)
+
+        assert coco.getAnns(imgIds=[999], catIds=[1]) == []
+        assert set(coco.img_ann_map) == before


### PR DESCRIPTION
`COCOeval._prepare` paid two per-annotation costs that did no work: it fetched annotations by round-tripping them through their own ids, and it crossed the Python/C++ boundary once per annotation to store them. On a 2,000 image x 300 detection bbox workload (600,000 detections, `maxDets=[1,10,500]`):

| Phase        |    Before |     After |               Change |
| ------------ | --------: | --------: | -------------------: |
| `_prepare`   | 0.33597 s | 0.14362 s | **2.3393x**, -57.25% |
| `evaluate()` | 0.85940 s | 0.64292 s | **1.3367x**, -25.19% |

Evaluator output digest — SHA-256 over the full precision, recall and scores tensors plus summary stats — is unchanged across every run.

**Commit 1, `fetch annotations without id round trip`** (1.3543x `_prepare` alone). `_prepare` called `loadAnns(getAnnIds(...))`; `getAnnIds` collects the annotation dicts, filters them, then discards them and returns only ids, and `loadAnns` validates every id and looks each back up — a per-annotation lambda, `isinstance` pair and dict lookup to recover objects the index already had. New `COCO.getAnns(imgIds, catIds)` returns them directly, matching `getAnnIds` selection and image iteration order exactly; public `getAnnIds`/`loadAnns` are untouched. It also reads `img_ann_map` via `.get`, so an unknown image id no longer inserts an empty list into the `defaultdict`.

**Commit 2, `batch annotation ingress into one call`** (1.7053x `_prepare` on top of commit 1). `append_ref` was called once per annotation at roughly 287 ns of pybind11 dispatch each — 0.17 s of pure boundary crossing to transfer two scalars and an object reference. New `LightweightDataset::append_batch(annotations, skip_dropped)` takes the whole sequence in one call and loops in C++, returning the `(image_id, category_id)` set that a second Python loop used to rebuild. **Review focus:** the first version tested the LVIS drop marker with `cast<bool>()`, which raises on a string-valued key where the `not dt.get("drop", False)` it replaced simply evaluates it — and annotations are user-supplied data, so `drop` can hold any object. The shipped version uses `PyObject_IsTrue`; all ten cases now match Python (missing, `False`, `True`, `0`, `1`, `None`, `""`, `"yes"`, `[]`, `[0]`). Neither the benchmark nor digest parity caught this, because the bbox fixture is `lvis_style=False` and never sets a drop key — unit tests cover it instead.

## Testing

Full suite **221 passed, 2 skipped** (209 before the new tests); `ruff check` and `ruff format` clean. 12 new tests: `TestGetAnns` asserts parity with `loadAnns(getAnnIds(...))` across five filter combinations, that returned dicts are the index's own objects (`_prepare` mutates them in place), and the `defaultdict` guard; `TestDatasetAppendBatch` parametrizes the ten drop values and checks the returned pair set.

## Benchmark method

Interleaved A/B over **frozen builds**: each configuration built, its package directory snapshotted, the two run alternately via `PYTHONPATH` — 7 outer rounds each, 5 inner per measurement, medians. Sequential before/after runs were not used, because an earlier reading here was confounded: a stale in-tree `.so` made the first "after" look like 1.898x, and rebuilding the baseline from clean sources put the true figure at 1.3367x. That staleness also produced 7 spurious `test_cpp_safety_regressions.py` failures that vanish after a rebuild.

## Limits

One host (macOS arm64, Python 3.10.11), one synthetic COCO2017-shaped bbox fixture — not real `instances_val2017.json` with real predictions. `getAnns` deliberately omits the `areaRng`/`iscrowd` filters `getAnnIds` supports, since `_prepare` does not use them; it is an internal fast path, not a replacement. LVIS drop handling is covered by unit tests only. Peak RSS was not measured.

## Not in this PR

Profiling alongside this work found the remaining bottleneck is not where the existing plan assumed: `get_cpp_instances`, the serial GIL-held prologue of `EvaluateImages`, holds roughly **78%** of the native call while the matching loops run parallel and nearly idle. The cost is `parse_py_annotation` rebuilding Python string keys per dict lookup — up to 14 transient strings per annotation, each allocated, UTF-8 decoded, siphash-hashed and freed. Tracked in `.plans/active/todo_native-matcher-optimization.md`. Separately, `.reports/analysis/bbox-bottleneck-and-freethreading-2026-08-24.md` records that the pinned cibuildwheel builds `cp314t` wheels by default while neither extension declares `Py_MOD_GIL_NOT_USED` — worth addressing before the next release, independently of this PR.
