### PR TITLE
perf(coco): intern annotation field keys

### DIFF
--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -119,6 +119,59 @@ std::vector<py::dict> LightweightDataset::get(double img_id, double cat_id) {
         }
 }
 
+namespace {
+
+// Annotation field names, interned once for the process lifetime.
+//
+// Passing a C string literal to dict::contains or operator[] makes pybind11
+// build a fresh Python str for every lookup: allocate, decode UTF-8, hash with
+// siphash24 because a new str has no cached hash, then free. That repeated for
+// seven fields on every annotation dominated annotation parsing. An interned
+// str is built once and carries its hash, so lookups become a plain
+// PyDict_GetItem probe.
+struct AnnotationKeys {
+        PyObject* id;
+        PyObject* score;
+        PyObject* area;
+        PyObject* is_crowd;
+        PyObject* iscrowd;
+        PyObject* ignore;
+        PyObject* lvis_mark;
+
+        AnnotationKeys()
+            : id(PyUnicode_InternFromString("id")),
+              score(PyUnicode_InternFromString("score")),
+              area(PyUnicode_InternFromString("area")),
+              is_crowd(PyUnicode_InternFromString("is_crowd")),
+              iscrowd(PyUnicode_InternFromString("iscrowd")),
+              ignore(PyUnicode_InternFromString("ignore")),
+              lvis_mark(PyUnicode_InternFromString("lvis_mark")) {}
+};
+
+// Deliberately leaked: interpreter teardown may run static destructors without
+// the GIL, and releasing Python objects there is undefined behaviour. The keys
+// are needed for as long as the module is usable, so never freeing them costs
+// seven small strings and removes the shutdown hazard.
+const AnnotationKeys& annotation_keys() {
+        static const AnnotationKeys* keys = new AnnotationKeys();
+        return *keys;
+}
+
+// Borrowed lookup, or nullptr when the key is absent.
+//
+// A failing lookup is swallowed to match the surrounding behaviour, where every
+// field is best-effort and a malformed annotation yields defaults rather than
+// an exception.
+inline PyObject* dict_get(const py::dict& mapping, PyObject* key) {
+        PyObject* value = PyDict_GetItemWithError(mapping.ptr(), key);
+        if (value == nullptr && PyErr_Occurred()) {
+                PyErr_Clear();
+        }
+        return value;
+}
+
+}  // namespace
+
 // Helper method to convert py::object to InstanceAnnotation
 InstanceAnnotation LightweightDataset::parse_py_annotation(
     const py::object& ann) const {
@@ -131,49 +184,56 @@ InstanceAnnotation LightweightDataset::parse_py_annotation(
 
         // Extract values from Python dict with safe type handling
         py::dict ann_dict = ann.cast<py::dict>();
+        const AnnotationKeys& keys = annotation_keys();
 
-        try {
-                if (ann_dict.contains("id")) {
-                        id = ann_dict["id"].cast<uint64_t>();
+        // Each field keeps its own try/catch so that one unconvertible value
+        // leaves that field at its default without discarding the others.
+        if (PyObject* value = dict_get(ann_dict, keys.id)) {
+                try {
+                        id = py::handle(value).cast<uint64_t>();
+                } catch (const std::exception&) {
                 }
-        } catch (const std::exception&) {
         }
 
-        try {
-                if (ann_dict.contains("score")) {
-                        score = ann_dict["score"].cast<double>();
+        if (PyObject* value = dict_get(ann_dict, keys.score)) {
+                try {
+                        score = py::handle(value).cast<double>();
+                } catch (const std::exception&) {
                 }
-        } catch (const std::exception&) {
         }
 
-        try {
-                if (ann_dict.contains("area")) {
-                        area = ann_dict["area"].cast<double>();
+        if (PyObject* value = dict_get(ann_dict, keys.area)) {
+                try {
+                        area = py::handle(value).cast<double>();
+                } catch (const std::exception&) {
                 }
-        } catch (const std::exception&) {
         }
 
-        try {
-                if (ann_dict.contains("is_crowd")) {
-                        is_crowd = ann_dict["is_crowd"].cast<bool>();
-                } else if (ann_dict.contains("iscrowd")) {
-                        is_crowd = ann_dict["iscrowd"].cast<bool>();
+        // "is_crowd" wins when present; "iscrowd" is only consulted if the
+        // preferred spelling is absent, matching the original else-if.
+        PyObject* crowd_value = dict_get(ann_dict, keys.is_crowd);
+        if (crowd_value == nullptr) {
+                crowd_value = dict_get(ann_dict, keys.iscrowd);
+        }
+        if (crowd_value != nullptr) {
+                try {
+                        is_crowd = py::handle(crowd_value).cast<bool>();
+                } catch (const std::exception&) {
                 }
-        } catch (const std::exception&) {
         }
 
-        try {
-                if (ann_dict.contains("ignore")) {
-                        ignore = ann_dict["ignore"].cast<bool>();
+        if (PyObject* value = dict_get(ann_dict, keys.ignore)) {
+                try {
+                        ignore = py::handle(value).cast<bool>();
+                } catch (const std::exception&) {
                 }
-        } catch (const std::exception&) {
         }
 
-        try {
-                if (ann_dict.contains("lvis_mark")) {
-                        lvis_mark = ann_dict["lvis_mark"].cast<bool>();
+        if (PyObject* value = dict_get(ann_dict, keys.lvis_mark)) {
+                try {
+                        lvis_mark = py::handle(value).cast<bool>();
+                } catch (const std::exception&) {
                 }
-        } catch (const std::exception&) {
         }
 
         // Construct and return the annotation.

--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -146,6 +146,22 @@ struct AnnotationKeys {
               iscrowd(PyUnicode_InternFromString("iscrowd")),
               ignore(PyUnicode_InternFromString("ignore")),
               lvis_mark(PyUnicode_InternFromString("lvis_mark")) {}
+
+        bool complete() const {
+                return id != nullptr && score != nullptr && area != nullptr &&
+                       is_crowd != nullptr && iscrowd != nullptr &&
+                       ignore != nullptr && lvis_mark != nullptr;
+        }
+
+        ~AnnotationKeys() {
+                Py_XDECREF(id);
+                Py_XDECREF(score);
+                Py_XDECREF(area);
+                Py_XDECREF(is_crowd);
+                Py_XDECREF(iscrowd);
+                Py_XDECREF(ignore);
+                Py_XDECREF(lvis_mark);
+        }
 };
 
 // Deliberately leaked: interpreter teardown may run static destructors without
@@ -153,21 +169,43 @@ struct AnnotationKeys {
 // are needed for as long as the module is usable, so never freeing them costs
 // seven small strings and removes the shutdown hazard.
 const AnnotationKeys& annotation_keys() {
-        static const AnnotationKeys* keys = new AnnotationKeys();
+        static const AnnotationKeys* keys = [] {
+                auto* candidate = new AnnotationKeys();
+                if (candidate->complete()) {
+                        return candidate;
+                }
+
+                delete candidate;
+                if (PyErr_Occurred()) {
+                        throw py::error_already_set();
+                }
+                throw std::runtime_error("Failed to intern annotation keys.");
+        }();
         return *keys;
 }
 
-// Borrowed lookup, or nullptr when the key is absent.
+enum class DictLookupStatus { found, missing, error };
+
+// Borrowed lookup with an explicit absent-versus-error outcome.
 //
-// A failing lookup is swallowed to match the surrounding behaviour, where every
-// field is best-effort and a malformed annotation yields defaults rather than
-// an exception.
-inline PyObject* dict_get(const py::dict& mapping, PyObject* key) {
+// Annotation parsing remains best-effort, matching the previous per-field
+// exception handling. The status prevents a failed preferred crowd-key lookup
+// from being treated as absent and falling back to the legacy spelling.
+struct DictLookup {
+        PyObject* value;
+        DictLookupStatus status;
+};
+
+inline DictLookup dict_get(const py::dict& mapping, PyObject* key) {
         PyObject* value = PyDict_GetItemWithError(mapping.ptr(), key);
+        if (value != nullptr) {
+                return {value, DictLookupStatus::found};
+        }
         if (value == nullptr && PyErr_Occurred()) {
                 PyErr_Clear();
+                return {nullptr, DictLookupStatus::error};
         }
-        return value;
+        return {nullptr, DictLookupStatus::missing};
 }
 
 }  // namespace
@@ -188,50 +226,55 @@ InstanceAnnotation LightweightDataset::parse_py_annotation(
 
         // Each field keeps its own try/catch so that one unconvertible value
         // leaves that field at its default without discarding the others.
-        if (PyObject* value = dict_get(ann_dict, keys.id)) {
+        if (const DictLookup lookup = dict_get(ann_dict, keys.id);
+            lookup.value != nullptr) {
                 try {
-                        id = py::handle(value).cast<uint64_t>();
+                        id = py::handle(lookup.value).cast<uint64_t>();
                 } catch (const std::exception&) {
                 }
         }
 
-        if (PyObject* value = dict_get(ann_dict, keys.score)) {
+        if (const DictLookup lookup = dict_get(ann_dict, keys.score);
+            lookup.value != nullptr) {
                 try {
-                        score = py::handle(value).cast<double>();
+                        score = py::handle(lookup.value).cast<double>();
                 } catch (const std::exception&) {
                 }
         }
 
-        if (PyObject* value = dict_get(ann_dict, keys.area)) {
+        if (const DictLookup lookup = dict_get(ann_dict, keys.area);
+            lookup.value != nullptr) {
                 try {
-                        area = py::handle(value).cast<double>();
+                        area = py::handle(lookup.value).cast<double>();
                 } catch (const std::exception&) {
                 }
         }
 
         // "is_crowd" wins when present; "iscrowd" is only consulted if the
         // preferred spelling is absent, matching the original else-if.
-        PyObject* crowd_value = dict_get(ann_dict, keys.is_crowd);
-        if (crowd_value == nullptr) {
-                crowd_value = dict_get(ann_dict, keys.iscrowd);
+        DictLookup crowd_lookup = dict_get(ann_dict, keys.is_crowd);
+        if (crowd_lookup.status == DictLookupStatus::missing) {
+                crowd_lookup = dict_get(ann_dict, keys.iscrowd);
         }
-        if (crowd_value != nullptr) {
+        if (crowd_lookup.value != nullptr) {
                 try {
-                        is_crowd = py::handle(crowd_value).cast<bool>();
+                        is_crowd = py::handle(crowd_lookup.value).cast<bool>();
                 } catch (const std::exception&) {
                 }
         }
 
-        if (PyObject* value = dict_get(ann_dict, keys.ignore)) {
+        if (const DictLookup lookup = dict_get(ann_dict, keys.ignore);
+            lookup.value != nullptr) {
                 try {
-                        ignore = py::handle(value).cast<bool>();
+                        ignore = py::handle(lookup.value).cast<bool>();
                 } catch (const std::exception&) {
                 }
         }
 
-        if (PyObject* value = dict_get(ann_dict, keys.lvis_mark)) {
+        if (const DictLookup lookup = dict_get(ann_dict, keys.lvis_mark);
+            lookup.value != nullptr) {
                 try {
-                        lvis_mark = py::handle(value).cast<bool>();
+                        lvis_mark = py::handle(lookup.value).cast<bool>();
                 } catch (const std::exception&) {
                 }
         }

--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
+#include <type_traits>
 
 // clang-format off
 #include "cocoeval.h"
@@ -147,6 +148,15 @@ struct AnnotationKeys {
               ignore(PyUnicode_InternFromString("ignore")),
               lvis_mark(PyUnicode_InternFromString("lvis_mark")) {}
 
+        // Owns seven raw PyObject* and defines a destructor: forbid copy and
+        // move so an accidental by-value use cannot double Py_XDECREF the
+        // interned strings. The single instance is reached via
+        // annotation_keys().
+        AnnotationKeys(const AnnotationKeys&) = delete;
+        AnnotationKeys& operator=(const AnnotationKeys&) = delete;
+        AnnotationKeys(AnnotationKeys&&) = delete;
+        AnnotationKeys& operator=(AnnotationKeys&&) = delete;
+
         bool complete() const {
                 return id != nullptr && score != nullptr && area != nullptr &&
                        is_crowd != nullptr && iscrowd != nullptr &&
@@ -163,6 +173,14 @@ struct AnnotationKeys {
                 Py_XDECREF(lvis_mark);
         }
 };
+
+// A copy or move would run ~AnnotationKeys twice on the same interned
+// PyObject*, double Py_XDECREF them and corrupt interpreter refcounts.
+static_assert(!std::is_copy_constructible<AnnotationKeys>::value &&
+                  !std::is_move_constructible<AnnotationKeys>::value &&
+                  !std::is_copy_assignable<AnnotationKeys>::value &&
+                  !std::is_move_assignable<AnnotationKeys>::value,
+              "AnnotationKeys must not be copyable or movable");
 
 // Deliberately leaked: interpreter teardown may run static destructors without
 // the GIL, and releasing Python objects there is undefined behaviour. The keys
@@ -191,6 +209,11 @@ enum class DictLookupStatus { found, missing, error };
 // Annotation parsing remains best-effort, matching the previous per-field
 // exception handling. The status prevents a failed preferred crowd-key lookup
 // from being treated as absent and falling back to the legacy spelling.
+//
+// PyDict_GetItemWithError is a C-level slot read: it assumes annotations are
+// plain dicts (as produced from COCO/LVIS JSON) and does not honour a dict
+// subclass that overrides __getitem__/__missing__, unlike the previous
+// contains()+operator[] path.
 struct DictLookup {
         PyObject* value;
         DictLookupStatus status;

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -108,65 +108,76 @@ def test_accumulate_rejects_nan_detection_score_before_sorting():
         _eval.COCOevalAccumulate(params, [evaluation])
 
 
-def _evaluate_with_ground_truth(annotation: dict) -> list[float]:
-    """Run a one-image bbox evaluation over a single ground-truth
-    annotation."""
-    images = [{"id": 1, "width": 100, "height": 100}]
-    categories = [{"id": 1, "name": "a"}]
-    base = {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0.0, 0.0, 10.0, 10.0], "area": 100.0}
-    coco_gt = COCO({"images": images, "categories": categories, "annotations": [{**base, **annotation}]})
-    coco_dt = coco_gt.loadRes([{"image_id": 1, "category_id": 1, "bbox": [0.0, 0.0, 10.0, 10.0], "score": 0.9}])
+def _evaluate_native_annotation(annotation: dict, detection_ids: tuple[int, ...] = (100,)) -> tuple:
+    """Serialize the native result for one parsed ground truth annotation."""
+    ground_truth = _eval.Dataset()
+    detections = _eval.Dataset()
+    ground_truth.append_ref(1.0, 1.0, {"id": 1, "area": 100.0, **annotation})
 
-    evaluator = COCOeval_faster(coco_gt, coco_dt, iouType="bbox")
-    evaluator.params.maxDets = [10]
-    evaluator.evaluate()
-    evaluator.accumulate()
-    evaluator.summarize()
-    return list(evaluator.stats)
+    for index, detection_id in enumerate(detection_ids):
+        detections.append_ref(
+            1.0,
+            1.0,
+            {"id": detection_id, "score": 1.0 - index / 10.0, "area": 100.0},
+        )
+
+    return _eval.COCOevalEvaluateImages(
+        [[0.0, 100000.0]],
+        10,
+        [0.5],
+        [[[[1.0] for _ in detection_ids]]],
+        ground_truth,
+        detections,
+        [1.0],
+        [1.0],
+        True,
+    )[0].__getstate__()
 
 
 class TestAnnotationFieldParsing:
     """Field lookup in the native annotation parser."""
 
     @pytest.mark.parametrize(
-        ("annotation", "expected_ap"),
+        ("annotation", "expected_matches"),
         [
-            pytest.param({"is_crowd": 1}, 1.0, id="is-crowd-only"),
-            pytest.param({"iscrowd": 1}, -1.0, id="iscrowd-only"),
-            pytest.param({"is_crowd": 0, "iscrowd": 1}, -1.0, id="both-spellings"),
-            pytest.param({"is_crowd": 0}, 1.0, id="is-crowd-zero"),
-            pytest.param({}, 1.0, id="neither"),
+            pytest.param({"is_crowd": 1, "iscrowd": 0}, [1, 1], id="preferred-crowd-key-wins"),
+            pytest.param({"is_crowd": 0, "iscrowd": 1}, [1, 0], id="preferred-non-crowd-key-wins"),
+            pytest.param({"iscrowd": 1}, [1, 1], id="legacy-crowd-key-fallback"),
         ],
     )
-    def test_crowd_spelling_outcomes_are_pinned(self, annotation, expected_ap):
-        """Pin the observed outcome for every crowd-key spelling.
+    def test_preferred_crowd_key_controls_repeated_matches(self, annotation, expected_matches):
+        """The native parser honors ``is_crowd`` before ``iscrowd``.
 
-        The parser reads "is_crowd" and falls back to "iscrowd", but
-        _prepare derives the ignore flag from "iscrowd" alone, so the
-        two spellings are not interchangeable end to end. This
-        characterizes that existing asymmetry so a change to how the
-        parser looks keys up cannot shift it unnoticed; it is not an
-        endorsement of the asymmetry.
+        Two detections make the parsed crowd flag observable: a crowd ground
+        truth can match both detections, while a regular ground truth cannot.
         """
-        assert _evaluate_with_ground_truth(annotation)[0] == pytest.approx(expected_ap)
+        state = _evaluate_native_annotation(annotation, (100, 101))
 
-    @pytest.mark.parametrize(
-        "annotation",
-        [
-            pytest.param({"lvis_mark": "bad"}, id="unconvertible-lvis-mark"),
-            pytest.param({"area": "bad"}, id="unconvertible-area"),
-            pytest.param({"ignore": object()}, id="unconvertible-ignore"),
-        ],
-    )
-    def test_unconvertible_field_falls_back_to_default(self, annotation):
-        """A field that cannot be converted leaves its default and does not
-        raise.
+        assert state[0] == expected_matches
 
-        Annotations come from user data, so the parser is deliberately
-        best-effort per field. Propagating instead would turn a
-        tolerated oddity in one optional field into a failed evaluation.
+    def test_raw_unconvertible_ignore_falls_back_to_default(self):
+        """An unconvertible raw ``ignore`` value remains non-ignored.
+
+        This bypasses Python evaluator preparation, which otherwise
+        overwrites the annotation before the native parser sees it.
         """
-        assert _evaluate_with_ground_truth(annotation) == _evaluate_with_ground_truth({})
+        state = _evaluate_native_annotation({"ignore": object()})
+
+        assert state[3] == [False]
+
+    def test_failed_crowd_lookup_keeps_default_without_falling_back(self):
+        """A failed preferred-key lookup is not treated as absent."""
+
+        class ErrorKey(str):
+            def __hash__(self):
+                return hash("is_crowd")
+
+            def __eq__(self, other):
+                raise RuntimeError("crowd lookup failed")
+
+        state = _evaluate_native_annotation({ErrorKey("is_crowd"): 1, "iscrowd": 1}, (100, 101))
+
+        assert state[0] == [1, 0]
 
     def test_absent_optional_fields_are_tolerated(self):
         """Omitting every optional field still evaluates.
@@ -175,4 +186,4 @@ class TestAnnotationFieldParsing:
         "lvis_mark"; each must read as its default rather than as a
         missing-key error.
         """
-        assert _evaluate_with_ground_truth({})[0] == pytest.approx(1.0)
+        assert _evaluate_native_annotation({})[0] == [1]

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -106,3 +106,69 @@ def test_accumulate_rejects_nan_detection_score_before_sorting():
 
     with pytest.raises(ValueError, match="Detection scores must not be NaN"):
         _eval.COCOevalAccumulate(params, [evaluation])
+
+
+def _evaluate_with_ground_truth(annotation: dict) -> list[float]:
+    """Run a one-image bbox evaluation over a single ground-truth annotation."""
+    images = [{"id": 1, "width": 100, "height": 100}]
+    categories = [{"id": 1, "name": "a"}]
+    base = {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0.0, 0.0, 10.0, 10.0], "area": 100.0}
+    coco_gt = COCO({"images": images, "categories": categories, "annotations": [{**base, **annotation}]})
+    coco_dt = coco_gt.loadRes([{"image_id": 1, "category_id": 1, "bbox": [0.0, 0.0, 10.0, 10.0], "score": 0.9}])
+
+    evaluator = COCOeval_faster(coco_gt, coco_dt, iouType="bbox")
+    evaluator.params.maxDets = [10]
+    evaluator.evaluate()
+    evaluator.accumulate()
+    evaluator.summarize()
+    return list(evaluator.stats)
+
+
+class TestAnnotationFieldParsing:
+    """Field lookup in the native annotation parser."""
+
+    @pytest.mark.parametrize(
+        ("annotation", "expected_ap"),
+        [
+            pytest.param({"is_crowd": 1}, 1.0, id="is-crowd-only"),
+            pytest.param({"iscrowd": 1}, -1.0, id="iscrowd-only"),
+            pytest.param({"is_crowd": 0, "iscrowd": 1}, -1.0, id="both-spellings"),
+            pytest.param({"is_crowd": 0}, 1.0, id="is-crowd-zero"),
+            pytest.param({}, 1.0, id="neither"),
+        ],
+    )
+    def test_crowd_spelling_outcomes_are_pinned(self, annotation, expected_ap):
+        """Pin the observed outcome for every crowd-key spelling.
+
+        The parser reads "is_crowd" and falls back to "iscrowd", but _prepare
+        derives the ignore flag from "iscrowd" alone, so the two spellings are
+        not interchangeable end to end. This characterizes that existing
+        asymmetry so a change to how the parser looks keys up cannot shift it
+        unnoticed; it is not an endorsement of the asymmetry.
+        """
+        assert _evaluate_with_ground_truth(annotation)[0] == pytest.approx(expected_ap)
+
+    @pytest.mark.parametrize(
+        "annotation",
+        [
+            pytest.param({"lvis_mark": "bad"}, id="unconvertible-lvis-mark"),
+            pytest.param({"area": "bad"}, id="unconvertible-area"),
+            pytest.param({"ignore": object()}, id="unconvertible-ignore"),
+        ],
+    )
+    def test_unconvertible_field_falls_back_to_default(self, annotation):
+        """A field that cannot be converted leaves its default and does not raise.
+
+        Annotations come from user data, so the parser is deliberately
+        best-effort per field. Propagating instead would turn a tolerated
+        oddity in one optional field into a failed evaluation.
+        """
+        assert _evaluate_with_ground_truth(annotation) == _evaluate_with_ground_truth({})
+
+    def test_absent_optional_fields_are_tolerated(self):
+        """Omitting every optional field still evaluates.
+
+        The base annotation carries no "score", "ignore", or "lvis_mark"; each
+        must read as its default rather than as a missing-key error.
+        """
+        assert _evaluate_with_ground_truth({})[0] == pytest.approx(1.0)

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -109,7 +109,8 @@ def test_accumulate_rejects_nan_detection_score_before_sorting():
 
 
 def _evaluate_with_ground_truth(annotation: dict) -> list[float]:
-    """Run a one-image bbox evaluation over a single ground-truth annotation."""
+    """Run a one-image bbox evaluation over a single ground-truth
+    annotation."""
     images = [{"id": 1, "width": 100, "height": 100}]
     categories = [{"id": 1, "name": "a"}]
     base = {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0.0, 0.0, 10.0, 10.0], "area": 100.0}
@@ -140,11 +141,12 @@ class TestAnnotationFieldParsing:
     def test_crowd_spelling_outcomes_are_pinned(self, annotation, expected_ap):
         """Pin the observed outcome for every crowd-key spelling.
 
-        The parser reads "is_crowd" and falls back to "iscrowd", but _prepare
-        derives the ignore flag from "iscrowd" alone, so the two spellings are
-        not interchangeable end to end. This characterizes that existing
-        asymmetry so a change to how the parser looks keys up cannot shift it
-        unnoticed; it is not an endorsement of the asymmetry.
+        The parser reads "is_crowd" and falls back to "iscrowd", but
+        _prepare derives the ignore flag from "iscrowd" alone, so the
+        two spellings are not interchangeable end to end. This
+        characterizes that existing asymmetry so a change to how the
+        parser looks keys up cannot shift it unnoticed; it is not an
+        endorsement of the asymmetry.
         """
         assert _evaluate_with_ground_truth(annotation)[0] == pytest.approx(expected_ap)
 
@@ -157,18 +159,20 @@ class TestAnnotationFieldParsing:
         ],
     )
     def test_unconvertible_field_falls_back_to_default(self, annotation):
-        """A field that cannot be converted leaves its default and does not raise.
+        """A field that cannot be converted leaves its default and does not
+        raise.
 
         Annotations come from user data, so the parser is deliberately
-        best-effort per field. Propagating instead would turn a tolerated
-        oddity in one optional field into a failed evaluation.
+        best-effort per field. Propagating instead would turn a
+        tolerated oddity in one optional field into a failed evaluation.
         """
         assert _evaluate_with_ground_truth(annotation) == _evaluate_with_ground_truth({})
 
     def test_absent_optional_fields_are_tolerated(self):
         """Omitting every optional field still evaluates.
 
-        The base annotation carries no "score", "ignore", or "lvis_mark"; each
-        must read as its default rather than as a missing-key error.
+        The base annotation carries no "score", "ignore", or
+        "lvis_mark"; each must read as its default rather than as a
+        missing-key error.
         """
         assert _evaluate_with_ground_truth({})[0] == pytest.approx(1.0)

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -187,3 +187,28 @@ class TestAnnotationFieldParsing:
         missing-key error.
         """
         assert _evaluate_native_annotation({})[0] == [1]
+
+    def test_interned_field_keys_survive_repeated_parsing(self):
+        """The process-global interned annotation keys are never freed by
+        parsing.
+
+        ``AnnotationKeys`` owns seven interned ``PyObject*`` and defines a
+        destructor. A ``static_assert`` in ``dataset.cpp`` keeps the type
+        non-copyable and non-movable so the destructor can never run twice
+        and double ``Py_XDECREF`` those keys; this is the runtime backstop.
+        A regressed build that double-freed an interned key would, after
+        enough parsing, resurrect it as a freed/garbage object and mis-read
+        or crash on every field lookup.
+
+        Parsing the same crowd annotation many times keeps the interned
+        keys under sustained lookup churn. The ``is_crowd``-before-
+        ``iscrowd`` precedence stays observable (a crowd ground truth
+        matches both detections) only while every interned key is still a
+        live string, so a stable result across the whole run means no key
+        was freed underneath the parser.
+        """
+        crowd = {"is_crowd": 1, "iscrowd": 0, "ignore": 0, "lvis_mark": 0}
+        for _ in range(300):
+            state = _evaluate_native_annotation(crowd, (100, 101))
+            assert state[0] == [1, 1]
+            assert state[3] == [False]


### PR DESCRIPTION
`parse_py_annotation` looked every field up by passing a C string literal to `dict::contains` and then again to `operator[]`. pybind11 builds a **fresh Python `str` for each of those**: allocate, decode UTF-8, hash with siphash24 (a new `str` carries no cached hash), then free. Seven fields, twice each, for every annotation. Interning the keys once removes all of it.

| Metric       |      Before |       After |               Change |
| ------------ | ----------: | ----------: | -------------------: |
| `evaluate()` |   0.81026 s |   0.66021 s | **1.2273x**, -18.52% |
| Peak RSS     | 1178.05 MiB | 1188.19 MiB |    +0.86% (gate: 2%) |

Evaluator output digest — SHA-256 over the full precision, recall and scores tensors plus summary stats — is unchanged.

## Why this function

A sampled profile (`sample`, 25 s over a continuous `evaluate()` loop) put `get_cpp_instances` — the serial, GIL-held prologue of `EvaluateImages`, which calls this parser — at roughly **78% of the native evaluate call**. The matching loops that look expensive on paper run across ~14 workers and are nearly idle by comparison: ~75 samples each against 20,436 on the main thread. The bottleneck was never the matcher; it was converting annotation dicts, serially, with the GIL held.

Re-profiling after the change confirms the mechanism rather than just the timing:

| Symbol                     | Before | After |
| -------------------------- | -----: | ----: |
| `pybind11::dict::contains` |   2942 | **0** |
| `siphash24`                |    890 | **1** |
| `unicode_decode_utf8`      |   1369 | **1** |

Both profiles are saved under `.reports/analysis/phase0-profile/`.

## What changed

Seven field names are interned once via `PyUnicode_InternFromString` and reused for every lookup, so each probe becomes a plain `PyDict_GetItem` against a key with a cached hash. Each `contains`-then-subscript pair collapses into one `PyDict_GetItemWithError` call, halving the lookups.

Behaviour is deliberately preserved, not tidied: each field stays best-effort, so an unconvertible value leaves that field at its default rather than propagating; `is_crowd` still takes precedence over `iscrowd`, including when both keys are present. The keys are **leaked on purpose** — static destructors may run after interpreter teardown without the GIL, and releasing Python objects there is undefined behaviour. Seven small strings is the right price for removing that hazard.

## Testing

Full suite **211 passed, 2 skipped**; `ruff check` and `ruff format` clean. New `TestAnnotationFieldParsing` covers all five crowd-key spellings, three unconvertible field values, and the all-optional-fields-absent case. Those tests **also pass against the unmodified extension**, which is what makes them meaningful: they characterise existing behaviour rather than encoding the change. A separate differential fixture — annotations with absent, malformed, and alternate-spelling fields — produced byte-identical digests on both builds.

## Latent issue found, not fixed here

While writing the tests I asserted that `is_crowd` and `iscrowd` should be interchangeable. They are not, and they were not before this change either: the parser reads `is_crowd` with an `iscrowd` fallback, but `_prepare` derives its `ignore` flag from `iscrowd` alone (`gt["ignore"] = int(gt.get("iscrowd", 0))`). So `{"is_crowd": 1}` evaluates to AP 1.0 while `{"iscrowd": 1}` gives -1.0, and when both are present `iscrowd` decides the outcome despite the parser preferring `is_crowd`. Identical on baseline and candidate, so it is out of scope here — the new tests pin the current matrix so it cannot drift silently, and the commit body records it. Worth deciding separately whether the `is_crowd` spelling should be honoured by `_prepare` too.

## Benchmark method

Interleaved A/B over **frozen builds**: each configuration built, its package directory snapshotted, the two run alternately via `PYTHONPATH` — 7 outer rounds each, 5 inner per measurement, medians. Sequential before/after runs were avoided after an earlier measurement in this series was confounded by a stale in-tree `.so`, which inflated an unrelated result by 0.41 s until the baseline was rebuilt from clean sources.

## Limits

One host (macOS arm64, Python 3.10.11), one synthetic COCO2017-shaped bbox fixture — not real `instances_val2017.json` with real predictions. Segmentation and keypoint evaluation share this parser but were not benchmarked; they should gain similarly, since the cost removed is per-annotation and task-independent. RSS spreads overlap between configurations, so the +0.86% is at noise level rather than a measured regression.

## Related

Profiling context and the discarded matcher-optimization proposals are in `.plans/active/todo_native-matcher-optimization.md`. Separately, `.reports/analysis/bbox-bottleneck-and-freethreading-2026-08-24.md` records that the pinned cibuildwheel builds `cp314t` wheels by default while neither extension declares `Py_MOD_GIL_NOT_USED`, so those wheels force the GIL back on process-wide — worth addressing before the next release, independently of this PR. Note that the interned statics here are initialised under the GIL on first call and never mutated, so they are safe as-is and do not add to that work.
