### PR TITLE
Support free-threaded CPython in native extensions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,15 +68,19 @@ jobs:
           python -m pytest -q test_torchmetrics.py test_world_evaluator.py test_extra_draw.py
 
   free-threaded:
-    name: Free-threaded CPython 3.14t (no-GIL)
+    name: Free-threaded CPython ${{ matrix.python-version }} (no-GIL)
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13t", "3.14t"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.14t"
+          python-version: ${{ matrix.python-version }}
 
       - name: Assert free-threaded interpreter
         shell: bash
@@ -102,17 +106,26 @@ jobs:
 
       - name: Import extensions without re-enabling the GIL
         shell: bash
+        working-directory: ./tests
         run: |
           set -euo pipefail
           python - <<'PY'
           import importlib
+          import os
           import sys
           import warnings
+          from pathlib import Path
 
           with warnings.catch_warnings():
               warnings.simplefilter("error")
-              importlib.import_module("faster_coco_eval.faster_eval_api_cpp")
-              importlib.import_module("faster_coco_eval.mask_api_new_cpp")
+              modules = (
+                  importlib.import_module("faster_coco_eval.faster_eval_api_cpp"),
+                  importlib.import_module("faster_coco_eval.mask_api_new_cpp"),
+              )
+          workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+          for module in modules:
+              if Path(module.__file__).resolve().is_relative_to(workspace):
+                  raise SystemExit(f"import resolved from checkout: {module.__file__}")
           if sys._is_gil_enabled():
               raise SystemExit("an extension import re-enabled the GIL")
           PY

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -132,4 +132,4 @@ jobs:
 
       - name: Run synchronized native stress regressions
         working-directory: ./tests
-        run: python -m pytest -q test_cpp_safety_regressions.py -k TestDatasetConcurrency
+        run: python -m pytest -q test_cpp_safety_regressions.py -k "TestDatasetConcurrency or test_concurrent_evaluator_and_mask_operations"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -66,3 +66,57 @@ jobs:
         working-directory: ./tests
         run: |
           python -m pytest -q test_torchmetrics.py test_world_evaluator.py test_extra_draw.py
+
+  free-threaded:
+    name: Free-threaded CPython 3.14t (no-GIL)
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14t"
+
+      - name: Assert free-threaded interpreter
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import sys
+          import sysconfig
+
+          if str(sysconfig.get_config_var("Py_GIL_DISABLED")) != "1":
+              raise SystemExit("Python build does not support free-threading")
+          if sys._is_gil_enabled():
+              raise SystemExit("GIL is enabled before extension imports")
+          PY
+
+      - name: Install from sdist
+        shell: bash
+        run: |
+          set -euo pipefail
+          pipx run build --sdist .
+          source_file=$(python -c "import glob,sys; files=glob.glob('dist/*.tar.gz'); (len(files)==1) or sys.exit(f'Expected 1 sdist in dist/, found {len(files)}: {files}'); print(files[0])")
+          python -m pip install "${source_file}[tests]"
+
+      - name: Import extensions without re-enabling the GIL
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import importlib
+          import sys
+          import warnings
+
+          with warnings.catch_warnings():
+              warnings.simplefilter("error")
+              importlib.import_module("faster_coco_eval.faster_eval_api_cpp")
+              importlib.import_module("faster_coco_eval.mask_api_new_cpp")
+          if sys._is_gil_enabled():
+              raise SystemExit("an extension import re-enabled the GIL")
+          PY
+
+      - name: Run synchronized native stress regressions
+        working-directory: ./tests
+        run: python -m pytest -q test_cpp_safety_regressions.py -k TestDatasetConcurrency

--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -21,23 +21,7 @@ LightweightDataset::LightweightDataset(LightweightDataset&& other) noexcept {
         std::lock_guard<std::mutex> guard(other.mutex);
         annotation_refs = std::move(other.annotation_refs);
         cpp_cache = std::move(other.cpp_cache);
-}
-
-LightweightDataset& LightweightDataset::operator=(
-    LightweightDataset&& other) noexcept {
-        if (this == &other) {
-                return *this;
-        }
-
-        // Order the two locks consistently so that concurrent a = b and b = a
-        // cannot deadlock.
-        std::lock(mutex, other.mutex);
-        std::lock_guard<std::mutex> self_guard(mutex, std::adopt_lock);
-        std::lock_guard<std::mutex> other_guard(other.mutex, std::adopt_lock);
-
-        annotation_refs = std::move(other.annotation_refs);
-        cpp_cache = std::move(other.cpp_cache);
-        return *this;
+        ++other.annotation_version;
 }
 
 // Store reference to annotation instead of copying data
@@ -48,21 +32,20 @@ void LightweightDataset::append_ref(double img_id, double cat_id,
 
         std::lock_guard<std::mutex> guard(mutex);
         annotation_refs[key].emplace_back(ann_ref);
+        cpp_cache.erase(key);
+        ++annotation_version;
 }
 
 // Remove all stored references and clear cache
 void LightweightDataset::clean() {
-        std::lock_guard<std::mutex> guard(mutex);
-        annotation_refs.clear();
-        cpp_cache.clear();
-
-        // Reclaim memory by swapping with empty containers
-        std::unordered_map<std::pair<int64_t, int64_t>, std::vector<py::object>,
-                           hash_pair>()
-            .swap(annotation_refs);
-        std::unordered_map<std::pair<int64_t, int64_t>,
-                           std::vector<InstanceAnnotation>, hash_pair>()
-            .swap(cpp_cache);
+        AnnotationRefs discarded_annotation_refs;
+        CppCache discarded_cpp_cache;
+        {
+                std::lock_guard<std::mutex> guard(mutex);
+                annotation_refs.swap(discarded_annotation_refs);
+                cpp_cache.swap(discarded_cpp_cache);
+                ++annotation_version;
+        }
 }
 
 // Get dataset size (number of (img_id, cat_id) pairs with annotations)
@@ -73,11 +56,15 @@ size_t LightweightDataset::size() const {
 
 // Serialize dataset contents to a tuple for pickle support
 py::tuple LightweightDataset::make_tuple() const {
-        std::lock_guard<std::mutex> guard(mutex);
+        AnnotationRefs annotations;
+        {
+                std::lock_guard<std::mutex> guard(mutex);
+                annotations = annotation_refs;
+        }
 
         // Create a list of (img_id, cat_id, annotation_list) tuples
         py::list serialized_data;
-        for (const auto& kv : annotation_refs) {
+        for (const auto& kv : annotations) {
                 auto key = kv.first;
                 auto ann_list = kv.second;
 
@@ -91,7 +78,7 @@ py::tuple LightweightDataset::make_tuple() const {
                     static_cast<double>(key.second), py_ann_list));
         }
 
-        return py::make_tuple(static_cast<int>(annotation_refs.size()),
+        return py::make_tuple(static_cast<int>(annotations.size()),
                               serialized_data);
 }
 
@@ -105,12 +92,8 @@ void LightweightDataset::load_tuple(py::tuple pickle_data) {
         int expected_size = pickle_data[0].cast<int>();
         py::list serialized_data = pickle_data[1].cast<py::list>();
 
-        std::lock_guard<std::mutex> guard(mutex);
-
-        // Clear existing data and reserve memory
-        annotation_refs.clear();
-        cpp_cache.clear();
-        annotation_refs.reserve(expected_size);
+        AnnotationRefs replacement_annotation_refs;
+        replacement_annotation_refs.reserve(expected_size);
 
         // Reconstruct data from serialized list
         for (auto item : serialized_data) {
@@ -130,7 +113,15 @@ void LightweightDataset::load_tuple(py::tuple pickle_data) {
                             py::reinterpret_borrow<py::object>(ann));
                 }
 
-                annotation_refs[key] = std::move(annotations);
+                replacement_annotation_refs[key] = std::move(annotations);
+        }
+
+        CppCache discarded_cpp_cache;
+        {
+                std::lock_guard<std::mutex> guard(mutex);
+                annotation_refs.swap(replacement_annotation_refs);
+                cpp_cache.swap(discarded_cpp_cache);
+                ++annotation_version;
         }
 }
 
@@ -139,21 +130,22 @@ std::vector<py::dict> LightweightDataset::get(double img_id, double cat_id) {
         const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
                                               static_cast<int64_t>(cat_id));
 
-        std::lock_guard<std::mutex> guard(mutex);
-        auto it = annotation_refs.find(key);
-        if (it != annotation_refs.end()) {
-                std::vector<py::dict> result;
-                result.reserve(it->second.size());
-
-                for (const auto& py_ann : it->second) {
-                        // Convert py::object to py::dict
-                        result.emplace_back(py_ann.cast<py::dict>());
+        std::vector<py::object> annotations;
+        {
+                std::lock_guard<std::mutex> guard(mutex);
+                auto it = annotation_refs.find(key);
+                if (it == annotation_refs.end()) {
+                        return {};
                 }
-
-                return result;
-        } else {
-                return {};
+                annotations = it->second;
         }
+
+        std::vector<py::dict> result;
+        result.reserve(annotations.size());
+        for (const auto& py_ann : annotations) {
+                result.emplace_back(py_ann.cast<py::dict>());
+        }
+        return result;
 }
 
 // Helper method to convert py::object to InstanceAnnotation
@@ -217,45 +209,50 @@ InstanceAnnotation LightweightDataset::parse_py_annotation(
         return InstanceAnnotation(id, score, area, is_crowd, ignore, lvis_mark);
 }
 
-// Cache lookup; caller must already hold mutex.
-const std::vector<InstanceAnnotation>&
-LightweightDataset::get_cpp_annotations_locked(
-    const std::pair<int64_t, int64_t>& key) const {
-        static const std::vector<InstanceAnnotation> kEmpty;
-
-        // Check cache first
-        auto cache_it = cpp_cache.find(key);
-        if (cache_it != cpp_cache.end()) {
-                return cache_it->second;
-        }
-
-        // If not in cache, get from annotation_refs and convert
-        auto it = annotation_refs.find(key);
-        if (it != annotation_refs.end()) {
-                std::vector<InstanceAnnotation> result;
-                result.reserve(it->second.size());
-
-                // Convert each Python annotation to InstanceAnnotation
-                for (const auto& py_ann : it->second) {
-                        result.emplace_back(parse_py_annotation(py_ann));
-                }
-
-                // Cache the result for future use
-                auto inserted = cpp_cache.emplace(key, std::move(result));
-                return inserted.first->second;
-        } else {
-                return kEmpty;
-        }
-}
-
 // Get C++ annotation objects with caching for performance
 std::vector<InstanceAnnotation> LightweightDataset::get_cpp_annotations(
     double img_id, double cat_id) const {
         const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
                                               static_cast<int64_t>(cat_id));
 
-        std::lock_guard<std::mutex> guard(mutex);
-        return get_cpp_annotations_locked(key);
+        for (;;) {
+                std::vector<py::object> annotations;
+                uint64_t snapshot_version = 0;
+                {
+                        std::lock_guard<std::mutex> guard(mutex);
+                        auto cache_it = cpp_cache.find(key);
+                        if (cache_it != cpp_cache.end()) {
+                                return cache_it->second;
+                        }
+
+                        auto annotation_it = annotation_refs.find(key);
+                        if (annotation_it == annotation_refs.end()) {
+                                return {};
+                        }
+                        annotations = annotation_it->second;
+                        snapshot_version = annotation_version;
+                }
+
+                std::vector<InstanceAnnotation> parsed_annotations;
+                parsed_annotations.reserve(annotations.size());
+                for (const auto& annotation : annotations) {
+                        parsed_annotations.emplace_back(
+                            parse_py_annotation(annotation));
+                }
+
+                // Conversion can run arbitrary Python hooks. Only publish its
+                // result when no writer has replaced its source annotations.
+                std::lock_guard<std::mutex> guard(mutex);
+                auto cache_it = cpp_cache.find(key);
+                if (cache_it != cpp_cache.end()) {
+                        return cache_it->second;
+                }
+                if (snapshot_version == annotation_version) {
+                        auto inserted = cpp_cache.emplace(
+                            key, std::move(parsed_annotations));
+                        return inserted.first->second;
+                }
+        }
 }
 
 // Clear cache entry for specific (img_id, cat_id) to free memory
@@ -275,11 +272,6 @@ LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
         std::vector<std::vector<std::vector<InstanceAnnotation>>> result;
         result.reserve(img_ids.size());  // Reserve space for image indices
 
-        // One lock for the whole sweep rather than one per pair: this runs once
-        // per evaluation over every image/category combination, so per-pair
-        // locking would add hundreds of thousands of uncontended acquisitions.
-        std::lock_guard<std::mutex> guard(mutex);
-
         for (size_t i = 0; i < img_ids.size(); ++i) {
                 int64_t img_id = static_cast<int64_t>(img_ids[i]);
                 if (useCats) {
@@ -292,8 +284,7 @@ LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
                                 int64_t cat_id =
                                     static_cast<int64_t>(cat_ids[j]);
                                 cat_results.emplace_back(
-                                    get_cpp_annotations_locked(
-                                        {img_id, cat_id}));
+                                    get_cpp_annotations(img_id, cat_id));
                         }
                         result.emplace_back(std::move(cat_results));
                 } else {
@@ -302,9 +293,8 @@ LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
                         for (size_t j = 0; j < cat_ids.size(); ++j) {
                                 int64_t cat_id =
                                     static_cast<int64_t>(cat_ids[j]);
-                                const std::vector<InstanceAnnotation>& anns =
-                                    get_cpp_annotations_locked(
-                                        {img_id, cat_id});
+                                const std::vector<InstanceAnnotation> anns =
+                                    get_cpp_annotations(img_id, cat_id);
                                 merged.insert(merged.end(), anns.begin(),
                                               anns.end());
                         }

--- a/csrc/faster_eval_api/coco_eval/dataset.cpp
+++ b/csrc/faster_eval_api/coco_eval/dataset.cpp
@@ -15,16 +15,44 @@ namespace coco_eval {
 
 namespace COCOeval {
 
+// Move construction: take the source's containers under its own lock, leaving
+// this object with a fresh, unlocked mutex of its own.
+LightweightDataset::LightweightDataset(LightweightDataset&& other) noexcept {
+        std::lock_guard<std::mutex> guard(other.mutex);
+        annotation_refs = std::move(other.annotation_refs);
+        cpp_cache = std::move(other.cpp_cache);
+}
+
+LightweightDataset& LightweightDataset::operator=(
+    LightweightDataset&& other) noexcept {
+        if (this == &other) {
+                return *this;
+        }
+
+        // Order the two locks consistently so that concurrent a = b and b = a
+        // cannot deadlock.
+        std::lock(mutex, other.mutex);
+        std::lock_guard<std::mutex> self_guard(mutex, std::adopt_lock);
+        std::lock_guard<std::mutex> other_guard(other.mutex, std::adopt_lock);
+
+        annotation_refs = std::move(other.annotation_refs);
+        cpp_cache = std::move(other.cpp_cache);
+        return *this;
+}
+
 // Store reference to annotation instead of copying data
 void LightweightDataset::append_ref(double img_id, double cat_id,
                                     py::object ann_ref) {
         const std::pair<int64_t, int64_t> key{static_cast<int64_t>(img_id),
                                               static_cast<int64_t>(cat_id)};
+
+        std::lock_guard<std::mutex> guard(mutex);
         annotation_refs[key].emplace_back(ann_ref);
 }
 
 // Remove all stored references and clear cache
 void LightweightDataset::clean() {
+        std::lock_guard<std::mutex> guard(mutex);
         annotation_refs.clear();
         cpp_cache.clear();
 
@@ -38,10 +66,15 @@ void LightweightDataset::clean() {
 }
 
 // Get dataset size (number of (img_id, cat_id) pairs with annotations)
-size_t LightweightDataset::size() const { return annotation_refs.size(); }
+size_t LightweightDataset::size() const {
+        std::lock_guard<std::mutex> guard(mutex);
+        return annotation_refs.size();
+}
 
 // Serialize dataset contents to a tuple for pickle support
 py::tuple LightweightDataset::make_tuple() const {
+        std::lock_guard<std::mutex> guard(mutex);
+
         // Create a list of (img_id, cat_id, annotation_list) tuples
         py::list serialized_data;
         for (const auto& kv : annotation_refs) {
@@ -71,6 +104,8 @@ void LightweightDataset::load_tuple(py::tuple pickle_data) {
         // Get size and data from tuple
         int expected_size = pickle_data[0].cast<int>();
         py::list serialized_data = pickle_data[1].cast<py::list>();
+
+        std::lock_guard<std::mutex> guard(mutex);
 
         // Clear existing data and reserve memory
         annotation_refs.clear();
@@ -103,6 +138,8 @@ void LightweightDataset::load_tuple(py::tuple pickle_data) {
 std::vector<py::dict> LightweightDataset::get(double img_id, double cat_id) {
         const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
                                               static_cast<int64_t>(cat_id));
+
+        std::lock_guard<std::mutex> guard(mutex);
         auto it = annotation_refs.find(key);
         if (it != annotation_refs.end()) {
                 std::vector<py::dict> result;
@@ -180,12 +217,11 @@ InstanceAnnotation LightweightDataset::parse_py_annotation(
         return InstanceAnnotation(id, score, area, is_crowd, ignore, lvis_mark);
 }
 
-// Get C++ annotation objects with caching for performance
-const std::vector<InstanceAnnotation>& LightweightDataset::get_cpp_annotations(
-    double img_id, double cat_id) const {
+// Cache lookup; caller must already hold mutex.
+const std::vector<InstanceAnnotation>&
+LightweightDataset::get_cpp_annotations_locked(
+    const std::pair<int64_t, int64_t>& key) const {
         static const std::vector<InstanceAnnotation> kEmpty;
-        const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
-                                              static_cast<int64_t>(cat_id));
 
         // Check cache first
         auto cache_it = cpp_cache.find(key);
@@ -212,10 +248,22 @@ const std::vector<InstanceAnnotation>& LightweightDataset::get_cpp_annotations(
         }
 }
 
+// Get C++ annotation objects with caching for performance
+std::vector<InstanceAnnotation> LightweightDataset::get_cpp_annotations(
+    double img_id, double cat_id) const {
+        const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
+                                              static_cast<int64_t>(cat_id));
+
+        std::lock_guard<std::mutex> guard(mutex);
+        return get_cpp_annotations_locked(key);
+}
+
 // Clear cache entry for specific (img_id, cat_id) to free memory
 void LightweightDataset::clear_cache_entry(double img_id, double cat_id) const {
         const std::pair<int64_t, int64_t> key(static_cast<int64_t>(img_id),
                                               static_cast<int64_t>(cat_id));
+
+        std::lock_guard<std::mutex> guard(mutex);
         cpp_cache.erase(key);
 }
 
@@ -226,6 +274,11 @@ LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
                                       const bool& useCats) const {
         std::vector<std::vector<std::vector<InstanceAnnotation>>> result;
         result.reserve(img_ids.size());  // Reserve space for image indices
+
+        // One lock for the whole sweep rather than one per pair: this runs once
+        // per evaluation over every image/category combination, so per-pair
+        // locking would add hundreds of thousands of uncontended acquisitions.
+        std::lock_guard<std::mutex> guard(mutex);
 
         for (size_t i = 0; i < img_ids.size(); ++i) {
                 int64_t img_id = static_cast<int64_t>(img_ids[i]);
@@ -239,7 +292,8 @@ LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
                                 int64_t cat_id =
                                     static_cast<int64_t>(cat_ids[j]);
                                 cat_results.emplace_back(
-                                    get_cpp_annotations(img_id, cat_id));
+                                    get_cpp_annotations_locked(
+                                        {img_id, cat_id}));
                         }
                         result.emplace_back(std::move(cat_results));
                 } else {
@@ -248,12 +302,11 @@ LightweightDataset::get_cpp_instances(const std::vector<double>& img_ids,
                         for (size_t j = 0; j < cat_ids.size(); ++j) {
                                 int64_t cat_id =
                                     static_cast<int64_t>(cat_ids[j]);
-                                std::vector<InstanceAnnotation> anns =
-                                    get_cpp_annotations(img_id, cat_id);
-                                merged.insert(
-                                    merged.end(),
-                                    std::make_move_iterator(anns.begin()),
-                                    std::make_move_iterator(anns.end()));
+                                const std::vector<InstanceAnnotation>& anns =
+                                    get_cpp_annotations_locked(
+                                        {img_id, cat_id});
+                                merged.insert(merged.end(), anns.begin(),
+                                              anns.end());
                         }
                         // Wrap merged vector in an outer vector for consistency
                         result.emplace_back(1, std::move(merged));

--- a/csrc/faster_eval_api/coco_eval/dataset.h
+++ b/csrc/faster_eval_api/coco_eval/dataset.h
@@ -3,6 +3,7 @@
 #include <pybind11/pybind11.h>
 
 #include <cstdint>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -35,6 +36,16 @@ class LightweightDataset {
                 annotation_refs.reserve(8192);
         }
 
+        // A std::mutex member is neither copyable nor movable, which would
+        // otherwise delete these implicitly and break the pickle __setstate__
+        // factory that returns a dataset by value. Move the containers and
+        // leave each object with its own fresh mutex; the source is locked so
+        // the move cannot race a concurrent reader.
+        LightweightDataset(LightweightDataset&& other) noexcept;
+        LightweightDataset& operator=(LightweightDataset&& other) noexcept;
+        LightweightDataset(const LightweightDataset&) = delete;
+        LightweightDataset& operator=(const LightweightDataset&) = delete;
+
         // Store reference to annotation instead of copying data
         void append_ref(double img_id, double cat_id, py::object ann_ref);
 
@@ -53,8 +64,13 @@ class LightweightDataset {
         // Get all Python dict annotations for a given image/category pair
         std::vector<py::dict> get(double img_id, double cat_id);
 
-        // Get C++ annotation objects with caching for performance
-        const std::vector<InstanceAnnotation>& get_cpp_annotations(
+        // Get C++ annotation objects with caching for performance.
+        //
+        // Returns by value rather than by reference: the cached entry it would
+        // otherwise expose can be erased by clear_cache_entry from another
+        // thread, so a reference outliving the lock would dangle. Every caller
+        // copied the result anyway.
+        std::vector<InstanceAnnotation> get_cpp_annotations(
             double img_id, double cat_id) const;
 
         // Clear cache entry for specific (img_id, cat_id) to free memory
@@ -90,6 +106,15 @@ class LightweightDataset {
 
         // Helper method to convert py::object to InstanceAnnotation
         InstanceAnnotation parse_py_annotation(const py::object& ann) const;
+
+        // Cache lookup assuming mutex is already held by the caller. Returns a
+        // reference valid only for as long as that lock is retained.
+        const std::vector<InstanceAnnotation>& get_cpp_annotations_locked(
+            const std::pair<int64_t, int64_t>& key) const;
+
+        // Guards annotation_refs and cpp_cache. Recursive locking is not
+        // supported, so locked helpers must never re-enter a public method.
+        mutable std::mutex mutex;
 };
 }  // namespace COCOeval
 }  // namespace coco_eval

--- a/csrc/faster_eval_api/coco_eval/dataset.h
+++ b/csrc/faster_eval_api/coco_eval/dataset.h
@@ -42,7 +42,6 @@ class LightweightDataset {
         // leave each object with its own fresh mutex; the source is locked so
         // the move cannot race a concurrent reader.
         LightweightDataset(LightweightDataset&& other) noexcept;
-        LightweightDataset& operator=(LightweightDataset&& other) noexcept;
         LightweightDataset(const LightweightDataset&) = delete;
         LightweightDataset& operator=(const LightweightDataset&) = delete;
 
@@ -94,26 +93,30 @@ class LightweightDataset {
         }
 
        private:
+        using AnnotationKey = std::pair<int64_t, int64_t>;
+        using AnnotationRefs =
+            std::unordered_map<AnnotationKey, std::vector<py::object>,
+                               hash_pair>;
+        using CppCache =
+            std::unordered_map<AnnotationKey, std::vector<InstanceAnnotation>,
+                               hash_pair>;
+
         // Lightweight storage: only references to Python objects
-        std::unordered_map<std::pair<int64_t, int64_t>, std::vector<py::object>,
-                           hash_pair>
-            annotation_refs;
+        AnnotationRefs annotation_refs;
 
         // Cache for frequently accessed InstanceAnnotation objects
-        mutable std::unordered_map<std::pair<int64_t, int64_t>,
-                                   std::vector<InstanceAnnotation>, hash_pair>
-            cpp_cache;
+        mutable CppCache cpp_cache;
+
+        // Increments whenever annotations are replaced or appended. Parsed
+        // data may be published only when this version still matches its
+        // source snapshot.
+        uint64_t annotation_version = 0;
 
         // Helper method to convert py::object to InstanceAnnotation
         InstanceAnnotation parse_py_annotation(const py::object& ann) const;
 
-        // Cache lookup assuming mutex is already held by the caller. Returns a
-        // reference valid only for as long as that lock is retained.
-        const std::vector<InstanceAnnotation>& get_cpp_annotations_locked(
-            const std::pair<int64_t, int64_t>& key) const;
-
-        // Guards annotation_refs and cpp_cache. Recursive locking is not
-        // supported, so locked helpers must never re-enter a public method.
+        // Guards annotation_refs, cpp_cache, and annotation_version. Python
+        // conversions and Python reference destruction must occur outside it.
         mutable std::mutex mutex;
 };
 }  // namespace COCOeval

--- a/csrc/faster_eval_api/faster_eval_api.cpp
+++ b/csrc/faster_eval_api/faster_eval_api.cpp
@@ -35,11 +35,8 @@ std::string get_compiler_version() {
         return ss.str();
 }
 
-// mod_gil_not_used declares this module safe on a free-threaded interpreter.
-// Without it, CPython warns and re-enables the GIL process-wide when the
-// module is imported, disabling free-threading for everything in the process.
-// LightweightDataset guards its own state with a mutex; the evaluator functions
-// own their working data and share nothing across calls.
+// Dataset state is mutex-protected, and evaluator calls own their working data.
+// Declare no-GIL safety so CPython does not re-enable the GIL at import.
 PYBIND11_MODULE(faster_eval_api_cpp, m, pybind11::mod_gil_not_used()) {
         // Expose utility and COCOeval functions to Python
         m.def("get_compiler_version", &get_compiler_version,

--- a/csrc/faster_eval_api/faster_eval_api.cpp
+++ b/csrc/faster_eval_api/faster_eval_api.cpp
@@ -36,8 +36,8 @@ std::string get_compiler_version() {
 }
 
 // mod_gil_not_used declares this module safe on a free-threaded interpreter.
-// Without it CPython re-enables the GIL process-wide when the module is
-// imported, silently disabling free-threading for everything in the process.
+// Without it, CPython warns and re-enables the GIL process-wide when the
+// module is imported, disabling free-threading for everything in the process.
 // LightweightDataset guards its own state with a mutex; the evaluator functions
 // own their working data and share nothing across calls.
 PYBIND11_MODULE(faster_eval_api_cpp, m, pybind11::mod_gil_not_used()) {

--- a/csrc/faster_eval_api/faster_eval_api.cpp
+++ b/csrc/faster_eval_api/faster_eval_api.cpp
@@ -35,7 +35,12 @@ std::string get_compiler_version() {
         return ss.str();
 }
 
-PYBIND11_MODULE(faster_eval_api_cpp, m) {
+// mod_gil_not_used declares this module safe on a free-threaded interpreter.
+// Without it CPython re-enables the GIL process-wide when the module is
+// imported, silently disabling free-threading for everything in the process.
+// LightweightDataset guards its own state with a mutex; the evaluator functions
+// own their working data and share nothing across calls.
+PYBIND11_MODULE(faster_eval_api_cpp, m, pybind11::mod_gil_not_used()) {
         // Expose utility and COCOeval functions to Python
         m.def("get_compiler_version", &get_compiler_version,
               "Returns the compiler version used for compilation.");

--- a/csrc/mask_api/mask_api.cpp
+++ b/csrc/mask_api/mask_api.cpp
@@ -63,7 +63,10 @@ std::string get_compiler_version() {
         return ss.str();
 }
 
-PYBIND11_MODULE(mask_api_new_cpp, m) {
+// See the note in faster_eval_api.cpp. The only process-wide mutable state
+// here is ParallelPermitPool, which is already mutex and condition-variable
+// guarded because these APIs release the GIL and are entered concurrently.
+PYBIND11_MODULE(mask_api_new_cpp, m, pybind11::mod_gil_not_used()) {
         // Exposes the RLE (Run-Length Encoding) class for binary masks.
         pybind11::class_<Mask::RLE>(m, "RLE")
             .def(pybind11::init<uint64_t, uint64_t, uint64_t,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires = [
     # with both numpy 1 and 2.
     "numpy>=2.0.0rc1",
     "Cython",
-    "pybind11>=2.12.0, <3",
+    # 2.13.0 is the first release exposing pybind11::mod_gil_not_used.
+    "pybind11>=2.13.0, <3",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires = [
     # with both numpy 1 and 2.
     "numpy>=2.0.0rc1",
     "Cython",
-    # 2.13.0 is the first release exposing pybind11::mod_gil_not_used.
-    "pybind11>=2.13.0, <3",
+    # 3.0.0 is the first release supporting CPython 3.14 and 3.14t.
+    "pybind11>=3.0.0, <4",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     python_requires=">=3.10",

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     python_requires=">=3.10",

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -111,6 +111,48 @@ def test_accumulate_rejects_nan_detection_score_before_sorting():
         _eval.COCOevalAccumulate(params, [evaluation])
 
 
+def _exercise_concurrent_evaluator_and_mask_operations():
+    """Run independent evaluator and mask calls from one synchronized start."""
+    barrier = threading.Barrier(4)
+
+    def evaluate_bbox():
+        coco_gt = COCO({
+            "images": [{"id": 1, "height": 2, "width": 2}],
+            "categories": [{"id": 1, "name": "object"}],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "bbox": [0, 0, 1, 1],
+                    "area": 1,
+                    "iscrowd": 0,
+                }
+            ],
+        })
+        coco_dt = coco_gt.loadRes([{"image_id": 1, "category_id": 1, "bbox": [0, 0, 1, 1], "score": 1.0}])
+        evaluator = COCOeval_faster(coco_gt, coco_dt, iouType="bbox", print_function=lambda _: None)
+
+        barrier.wait()
+        evaluator.evaluate()
+        evaluator.accumulate()
+        return evaluator.eval["precision"].shape
+
+    def evaluate_mask():
+        rle = _mask.frUncompressedRLE([{"size": [2, 2], "counts": [1, 3]}])
+
+        barrier.wait()
+        return _mask.toBbox(rle).tolist()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(evaluate_bbox) for _ in range(2)]
+        futures.extend(pool.submit(evaluate_mask) for _ in range(2))
+        results = [future.result() for future in futures]
+
+    assert results[:2] == [(10, 101, 1, 4, 3)] * 2
+    assert results[2:] == [[[0.0, 0.0, 2.0, 2.0]]] * 2
+
+
 def _populated_dataset(pairs: int = 64):
     """Build a dataset spanning several image/category pairs."""
     dataset = _eval.Dataset()
@@ -254,6 +296,10 @@ class TestDatasetConcurrency:
     def test_concurrent_readers_complete(self):
         """Synchronized cache readers finish within an external timeout."""
         _assert_completes_in_subprocess(_exercise_concurrent_readers)
+
+    def test_concurrent_evaluator_and_mask_operations(self):
+        """Independent evaluator and mask calls cannot deadlock the process."""
+        _assert_completes_in_subprocess(_exercise_concurrent_evaluator_and_mask_operations)
 
     def test_reads_interleaved_with_cache_eviction_complete(self):
         """Synchronized readers and evictors return whole cache entries."""

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -124,9 +124,9 @@ class TestDatasetConcurrency:
     def test_concurrent_readers_complete(self):
         """Many threads reading the cache finish and agree on the contents.
 
-        get_cpp_annotations populates a shared cache on miss, so the read path
-        mutates. A recursive or mis-ordered lock here would deadlock and hang
-        the suite rather than fail an assertion.
+        get_cpp_annotations populates a shared cache on miss, so the
+        read path mutates. A recursive or mis-ordered lock here would
+        deadlock and hang the suite rather than fail an assertion.
         """
         dataset = self._populated_dataset()
         results = []
@@ -144,8 +144,8 @@ class TestDatasetConcurrency:
         """Reads racing cache eviction return whole annotation lists.
 
         clear_cache_entry erases entries that get_cpp_annotations may be
-        populating. Returning by value keeps callers safe from an entry being
-        dropped mid-use; a reference would dangle instead.
+        populating. Returning by value keeps callers safe from an entry
+        being dropped mid-use; a reference would dangle instead.
         """
         dataset = self._populated_dataset()
         observed = []

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -1,7 +1,9 @@
 """Regression coverage for C++ input-validation boundaries."""
 
 import math
+import multiprocessing
 import pickle
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
@@ -109,57 +111,195 @@ def test_accumulate_rejects_nan_detection_score_before_sorting():
         _eval.COCOevalAccumulate(params, [evaluation])
 
 
+def _populated_dataset(pairs: int = 64):
+    """Build a dataset spanning several image/category pairs."""
+    dataset = _eval.Dataset()
+    for index in range(pairs):
+        dataset.append_ref(index, 1, {"id": index, "area": 10.0, "iscrowd": 0})
+        dataset.append_ref(index, 1, {"id": index + 1000, "area": 20.0, "iscrowd": 1})
+    return dataset
+
+
+def _exercise_concurrent_readers():
+    """Synchronize readers before they populate the shared native cache."""
+    dataset = _populated_dataset()
+    barrier = threading.Barrier(8)
+    results = []
+
+    def read_all():
+        barrier.wait()
+        results.append([len(dataset.get_cpp_annotations(i, 1)) for i in range(64)])
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda _: read_all(), range(8)))
+
+    assert results == [[2] * 64] * 8
+
+
+def _exercise_reads_with_cache_eviction():
+    """Synchronize cache readers and eviction workers before contention."""
+    dataset = _populated_dataset()
+    barrier = threading.Barrier(6)
+    observed = []
+
+    def read():
+        barrier.wait()
+        observed.extend(len(dataset.get_cpp_annotations(i, 1)) for i in range(64))
+
+    def evict():
+        barrier.wait()
+        for index in range(64):
+            dataset.clear_cache_entry(index, 1)
+
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        futures = [pool.submit(read if index % 2 == 0 else evict) for index in range(6)]
+        for future in futures:
+            future.result()
+
+    assert set(observed) == {2}
+
+
+def _exercise_clean_finalizer_reentry():
+    """Re-enter Dataset while clean releases its annotation references."""
+    dataset = _eval.Dataset()
+
+    class ReenterDataset(dict):
+        def __del__(self):
+            len(dataset)
+
+    dataset.append_ref(1, 1, ReenterDataset(id=1, area=10.0, iscrowd=0))
+    dataset.clean()
+    assert len(dataset) == 0
+
+
+def _exercise_load_finalizer_reentry():
+    """Re-enter Dataset while load_tuple replaces existing annotations."""
+    dataset = _eval.Dataset()
+
+    class ReenterDataset(dict):
+        def __del__(self):
+            len(dataset)
+
+    dataset.append_ref(1, 1, ReenterDataset(id=1, area=10.0, iscrowd=0))
+    dataset.load_tuple((0, []))
+    assert len(dataset) == 0
+
+
+def _exercise_load_conversion_reentry():
+    """Re-enter Dataset through a numeric conversion in load_tuple."""
+    dataset = _eval.Dataset()
+
+    class ReenterFloat:
+        def __float__(self):
+            len(dataset)
+            return 1.0
+
+    dataset.load_tuple((1, [(ReenterFloat(), 1.0, [{"id": 1}])]))
+    assert len(dataset) == 1
+
+
+def _exercise_parse_conversion_reentry():
+    """Re-enter Dataset through annotation conversion on a cache miss."""
+    dataset = _eval.Dataset()
+
+    class ReenterFloat:
+        def __float__(self):
+            len(dataset)
+            return 10.0
+
+    dataset.append_ref(1, 1, {"id": 1, "area": ReenterFloat(), "iscrowd": 0})
+    assert len(dataset.get_cpp_annotations(1, 1)) == 1
+
+
+def _exercise_writer_during_conversion():
+    """Prevent a converted stale snapshot from replacing a newer cache."""
+    dataset = _eval.Dataset()
+    conversion_started = threading.Event()
+    append_completed = threading.Event()
+
+    class WaitForAppend:
+        def __float__(self):
+            conversion_started.set()
+            append_completed.wait()
+            return 10.0
+
+    dataset.append_ref(1, 1, {"id": 1, "area": WaitForAppend(), "iscrowd": 0})
+
+    def append_annotation():
+        conversion_started.wait()
+        dataset.append_ref(1, 1, {"id": 2, "area": 20.0, "iscrowd": 0})
+        append_completed.set()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        append_future = pool.submit(append_annotation)
+        assert len(dataset.get_cpp_annotations(1, 1)) == 2
+        append_future.result()
+
+
+def _assert_completes_in_subprocess(target):
+    """Fail externally when a deadlock-sensitive scenario does not finish."""
+    process = multiprocessing.get_context("spawn").Process(target=target)
+    process.start()
+    process.join(timeout=15)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        pytest.fail(f"{target.__name__} did not complete within 15 seconds")
+    assert process.exitcode == 0
+
+
 class TestDatasetConcurrency:
     """Locking behaviour of the native dataset cache."""
 
-    @staticmethod
-    def _populated_dataset(pairs: int = 64):
-        """Build a dataset spanning several image/category pairs."""
-        dataset = _eval.Dataset()
-        for index in range(pairs):
-            dataset.append_ref(index, 1, {"id": index, "area": 10.0, "iscrowd": 0})
-            dataset.append_ref(index, 1, {"id": index + 1000, "area": 20.0, "iscrowd": 1})
-        return dataset
-
     def test_concurrent_readers_complete(self):
-        """Many threads reading the cache finish and agree on the contents.
-
-        get_cpp_annotations populates a shared cache on miss, so the
-        read path mutates. A recursive or mis-ordered lock here would
-        deadlock and hang the suite rather than fail an assertion.
-        """
-        dataset = self._populated_dataset()
-        results = []
-
-        def read_all():
-            results.append([len(dataset.get_cpp_annotations(i, 1)) for i in range(64)])
-
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            for future in [pool.submit(read_all) for _ in range(8)]:
-                future.result(timeout=60)
-
-        assert results == [[2] * 64] * 8
+        """Synchronized cache readers finish within an external timeout."""
+        _assert_completes_in_subprocess(_exercise_concurrent_readers)
 
     def test_reads_interleaved_with_cache_eviction_complete(self):
-        """Reads racing cache eviction return whole annotation lists.
+        """Synchronized readers and evictors return whole cache entries."""
+        _assert_completes_in_subprocess(_exercise_reads_with_cache_eviction)
 
-        clear_cache_entry erases entries that get_cpp_annotations may be
-        populating. Returning by value keeps callers safe from an entry
-        being dropped mid-use; a reference would dangle instead.
-        """
-        dataset = self._populated_dataset()
-        observed = []
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            pytest.param(_exercise_clean_finalizer_reentry, id="clean-finalizer"),
+            pytest.param(_exercise_load_finalizer_reentry, id="load-finalizer"),
+            pytest.param(_exercise_load_conversion_reentry, id="load-conversion"),
+            pytest.param(_exercise_parse_conversion_reentry, id="parse-conversion"),
+        ],
+    )
+    def test_python_reentry_completes(self, scenario):
+        """Python callbacks cannot self-deadlock on the Dataset mutex."""
+        _assert_completes_in_subprocess(scenario)
 
-        def read():
-            observed.extend(len(dataset.get_cpp_annotations(i, 1)) for i in range(64))
+    def test_writer_during_conversion_does_not_publish_stale_cache(self):
+        """A cache miss retries when a writer changes its source snapshot."""
+        _assert_completes_in_subprocess(_exercise_writer_during_conversion)
 
-        def evict():
-            for i in range(64):
-                dataset.clear_cache_entry(i, 1)
+    def test_append_invalidates_parsed_cache(self):
+        """Native reads include annotations appended after cache population."""
+        dataset = _eval.Dataset()
+        dataset.append_ref(1, 1, {"id": 1, "area": 10.0, "iscrowd": 0})
+        assert len(dataset.get_cpp_annotations(1, 1)) == 1
 
-        with ThreadPoolExecutor(max_workers=6) as pool:
-            futures = [pool.submit(read if n % 2 == 0 else evict) for n in range(6)]
-            for future in futures:
-                future.result(timeout=60)
+        dataset.append_ref(1, 1, {"id": 2, "area": 20.0, "iscrowd": 0})
 
-        assert set(observed) == {2}
+        assert [annotation["id"] for annotation in dataset.get(1, 1)] == [1, 2]
+        assert len(dataset.get_cpp_annotations(1, 1)) == 2
+
+    def test_dataset_pickle_round_trip_preserves_python_and_native_data(self):
+        """Dataset pickle exercises __setstate__ and preserves all contents."""
+        dataset = _eval.Dataset()
+        annotations = [
+            {"id": 1, "area": 10.0, "iscrowd": 0},
+            {"id": 2, "area": 20.0, "iscrowd": 1},
+        ]
+        for annotation in annotations:
+            dataset.append_ref(1, 1, annotation)
+        dataset.append_ref(2, 1, {"id": 3, "area": 30.0, "iscrowd": 0})
+
+        restored = pickle.loads(pickle.dumps(dataset))
+
+        assert len(restored) == 2
+        assert restored.get(1, 1) == annotations
+        assert [len(restored.get_cpp_annotations(image_id, 1)) for image_id in (1, 2)] == [2, 1]

--- a/tests/test_cpp_safety_regressions.py
+++ b/tests/test_cpp_safety_regressions.py
@@ -2,6 +2,7 @@
 
 import math
 import pickle
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import faster_coco_eval.faster_eval_api_cpp as _eval
@@ -106,3 +107,59 @@ def test_accumulate_rejects_nan_detection_score_before_sorting():
 
     with pytest.raises(ValueError, match="Detection scores must not be NaN"):
         _eval.COCOevalAccumulate(params, [evaluation])
+
+
+class TestDatasetConcurrency:
+    """Locking behaviour of the native dataset cache."""
+
+    @staticmethod
+    def _populated_dataset(pairs: int = 64):
+        """Build a dataset spanning several image/category pairs."""
+        dataset = _eval.Dataset()
+        for index in range(pairs):
+            dataset.append_ref(index, 1, {"id": index, "area": 10.0, "iscrowd": 0})
+            dataset.append_ref(index, 1, {"id": index + 1000, "area": 20.0, "iscrowd": 1})
+        return dataset
+
+    def test_concurrent_readers_complete(self):
+        """Many threads reading the cache finish and agree on the contents.
+
+        get_cpp_annotations populates a shared cache on miss, so the read path
+        mutates. A recursive or mis-ordered lock here would deadlock and hang
+        the suite rather than fail an assertion.
+        """
+        dataset = self._populated_dataset()
+        results = []
+
+        def read_all():
+            results.append([len(dataset.get_cpp_annotations(i, 1)) for i in range(64)])
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            for future in [pool.submit(read_all) for _ in range(8)]:
+                future.result(timeout=60)
+
+        assert results == [[2] * 64] * 8
+
+    def test_reads_interleaved_with_cache_eviction_complete(self):
+        """Reads racing cache eviction return whole annotation lists.
+
+        clear_cache_entry erases entries that get_cpp_annotations may be
+        populating. Returning by value keeps callers safe from an entry being
+        dropped mid-use; a reference would dangle instead.
+        """
+        dataset = self._populated_dataset()
+        observed = []
+
+        def read():
+            observed.extend(len(dataset.get_cpp_annotations(i, 1)) for i in range(64))
+
+        def evict():
+            for i in range(64):
+                dataset.clear_cache_entry(i, 1)
+
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            futures = [pool.submit(read if n % 2 == 0 else evict) for n in range(6)]
+            for future in futures:
+                future.result(timeout=60)
+
+        assert set(observed) == {2}


### PR DESCRIPTION
## Summary

Enable `faster_coco_eval` to load on free-threaded CPython without re-enabling the GIL for the entire process.

- Declare both pybind11 extension modules safe for free-threaded interpreters.
- Synchronize the mutable native `Dataset` cache and avoid exposing cache references after their lock is released.
- Require the first pybind11 release that provides `mod_gil_not_used`.
- Run the normal installed-sdist suite on CPython 3.10-3.14 across Linux, macOS, and Windows, plus no-GIL gates on 3.13t and 3.14t.

## Why this matters

Before this change, importing either native extension on CPython 3.14t warns and enables the GIL process-wide. Evaluation results remain correct, but other Python threads lose free-threaded execution. With this change, the GIL remains disabled after both extensions are imported.

The expected benefit is concurrent throughput, not lower latency for one COCO evaluation.

## Python 3.14t benchmark

CPython 3.14.2 free-threaded on macOS arm64. Each row uses two warmups and 15 alternating fresh-process base/PR pairs. The bbox workload contains 200 images and 10,000 detections with `maxDets=[1, 10, 50]`; each worker owns an independent evaluator.

| Concurrent evaluators |         Base |           PR | Throughput gain | Paired 95% interval | Favorable pairs |
| --------------------: | -----------: | -----------: | --------------: | ------------------: | --------------: |
|                     1 | 14.06 eval/s | 14.20 eval/s |           1.01x |        0.995-1.028x |            9/15 |
|                     2 | 11.68 eval/s | 19.01 eval/s |       **1.61x** |          1.49-1.66x |           15/15 |
|                     4 |  7.69 eval/s | 29.07 eval/s |       **3.76x** |          3.54-4.00x |           15/15 |

Four concurrent evaluations complete in 0.13760 seconds with the PR versus 0.52048 seconds on the base revision. Every run produced the same exact result digest.

Standard CPython 3.13.15 also produced the same digest. An extended alternating A/B run measured a 0.91% total-time change and a -0.03% peak-RSS change, so the synchronization cost remained below the predeclared 3% regression guard.

Benchmark revisions:

- Base: `123cc73a1da42420d77e230c9d02cba8b4d83ac3`
- Measured implementation: `b67e5d163c0ee350051962e8f1351188a0ddeec0`

## Safety and reliability

- All mutable `Dataset` containers and cache versions are mutex-protected.
- Python conversions and Python reference destruction occur outside the mutex, preventing callback/finalizer re-entry deadlocks.
- Cache misses publish parsed data only if the annotation version still matches the source snapshot.
- Cached annotations return by value so concurrent eviction cannot leave a dangling reference.
- CI runs the standard sdist suite on CPython 3.10-3.14 across three operating systems. Separate 3.13t/3.14t jobs import outside the checkout, treat warnings as errors, check that the GIL remains disabled, and run the contention regressions.

## Verification

- CPython 3.14.2t: both extensions imported with the GIL still disabled.
- CPython 3.14.2t: `16 passed` in `test_cpp_safety_regressions.py`.
- CPython 3.10.11: full suite `211 passed, 2 skipped`.
- C++ formatting hook: passed on the focused evaluator-module change.
- Hosted standard 3.14 and free-threaded 3.13t/3.14t jobs: pending until this PR revision runs in GitHub Actions.

## Claim boundary

This PR does not make one evaluation materially faster and does not claim universal linear scaling, shared-mutable-`Dataset` scaling, or cross-platform equivalence. The measured 1.61-3.76x gain applies to 2-4 independent evaluators on one synthetic bbox workload and one macOS arm64 host.
